### PR TITLE
build(dependabot): address initial dependabot findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: go
 
-      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/autobuild@v4
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean
@@ -41,17 +41,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ghcr.io/vulncheck-oss/mcp

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/stretchr/testify v1.11.1
-	github.com/vulncheck-oss/sdk-go-v2/v2 v2.1.21
+	github.com/vulncheck-oss/sdk-go-v2/v2 v2.1.22
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfv
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vulncheck-oss/sdk-go-v2/v2 v2.1.21 h1:LwcHnhLbMwGHHXF2jdjJLuW7gL1N/oqQQBGd7nzcaZs=
-github.com/vulncheck-oss/sdk-go-v2/v2 v2.1.21/go.mod h1:EXqRvNHUnO4QIC7OaIleh9hJw+Wg7cNAebsONqc2kz0=
+github.com/vulncheck-oss/sdk-go-v2/v2 v2.1.22 h1:E/O+XvHo+2EwxTBB2GbLpB33hOmu00JavIcsccWKt7g=
+github.com/vulncheck-oss/sdk-go-v2/v2 v2.1.22/go.mod h1:EXqRvNHUnO4QIC7OaIleh9hJw+Wg7cNAebsONqc2kz0=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=


### PR DESCRIPTION
This takes care of all 6 low-risk dependency issues raised by dependabot on the initial commit.

closes #7
