### PR TITLE
chore: high-level release review

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_BUG-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/1_BUG-FORM.yaml
@@ -1,0 +1,52 @@
+name: 🐞 Bug
+description: Report a bug/issue
+title: "[BUG] <title>"
+labels: [bug]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: What happened?
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. Run '...'
+      3. See error...
+  validations:
+    required: false
+- type: dropdown
+  id: os-system
+  attributes:
+    label: Which operating system where you on?
+    options:
+      - Windows
+      - Mac
+      - Linux
+      - Other
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/2_FEATURE-REQUEST-FORM.yaml
+++ b/.github/ISSUE_TEMPLATE/2_FEATURE-REQUEST-FORM.yaml
@@ -1,0 +1,35 @@
+name: 🏗️ Feature
+description: Feature request
+title: "[FEATURE] <title>"
+labels: [improvement]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature request.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Issue / Request Related to a Problem?
+    description: A clear and concise description of what the problem is.
+    placeholder: ex. I'm always frustrated when [...].
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Solution
+    description: Sequence of steps needed to complete this feature.
+    value: |
+      - [ ] Step 1
+      - [ ] Step 2
+      - [ ] Step 3   
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional Context
+    description: Add any other context or screenshots about the feature request here.
+  validations:
+    required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,10 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/). 
 
 - Go 1.26+
 - A VulnCheck API token for integration testing
+
+## Submitting a pull request
+
+1. Create a new branch: git checkout -b my-branch-name
+2. Make your change, add tests, and ensure tests pass
+3. Update any relevant documentation
+4. Submit a pull request: gh pr create --web

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 ARG VERSION=dev
+ENV GOTOOLCHAIN=local CGO_ENABLED=0
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/root/.cache/go-build go mod download
-COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION}" -o /vulncheck-mcp ./cmd/vulncheck-mcp
+    go mod download && go mod verify
+COPY cmd/ ./cmd/
+COPY internal/ ./internal/
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
+        -o /vulncheck-mcp ./cmd/vulncheck-mcp
 
 FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
 LABEL io.modelcontextprotocol.server.name="io.github.vulncheck-oss/mcp"
 COPY --from=builder /vulncheck-mcp /vulncheck-mcp
-EXPOSE 8080
 ENTRYPOINT ["/vulncheck-mcp"]
 CMD ["-transport", "stdio"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# vulncheck-mcp
+<p align="center">
+    <img src="https://vulncheck.com/logo.png" align="center" alt="VulnCheck Logo" width="150" />
+</p>
 
+# The VulnCheck MCP Server
 The VulnCheck MCP Server connects AI assistants to [VulnCheck](https://vulncheck.com) vulnerability intelligence. Ask your AI tools about CVEs, exploits, advisories, and vulnerable packages — directly in your editor or terminal, using natural language.
 
 ### Use Cases
@@ -9,8 +12,6 @@ The VulnCheck MCP Server connects AI assistants to [VulnCheck](https://vulncheck
 - **Exploit intelligence**: Determine whether a CVE has known exploit code, active exploitation, or C2 indicators
 - **Advisory lookup**: Search vendor and ecosystem advisories by package, product, or keyword
 - **Index queries**: Query VulnCheck's breach, botnet, and threat intelligence indices for real-time context
-
----
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Small quality and posture improvements across the repo; no functional changes to the server itself.

### Dockerfile hardening (fc94147)
- Pin the Go toolchain with `GOTOOLCHAIN=local` so the digest-pinned base image actually determines the compiler used.
- Add `go mod verify` after `go mod download` to fail the build on `go.sum` mismatch.
- Add `-trimpath` to `go build` to strip local filesystem paths from the binary (reproducible builds, no path leakage).
- Narrow the build context from `COPY . .` to `COPY cmd/ ./cmd/` + `COPY internal/ ./internal/`.
- Drop `EXPOSE 8080` the default transport is stdio.

### README polish (a98c5bf)
- Add the VulnCheck logo at the top.
- Promote the title to "The VulnCheck MCP Server".

### CONTRIBUTING (49b91c9)
- Add a short "Submitting a pull request" section with the standard branch → change → test → PR flow.

### Issue templates (3c635a9)
- Add `.github/ISSUE_TEMPLATE/1_BUG-FORM.yaml` and `2_FEATURE-REQUEST-FORM.yaml` so bug reports and feature requests come in with consistent structure.