### PR TITLE
ops(goreleaser): pass tag ref to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - uses: actions/attest-build-provenance@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,3 +40,4 @@ changelog:
 
 release:
   prerelease: auto
+  mode: replace


### PR DESCRIPTION
In addition, configure goreleaser to replace artifacts so that it can be safely re-run on a failed job with the same tag ref.

closes #26
