### PR TITLE
feat(#41): Adds get_cve_affected_products, resolving a CVE to the software it affects

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -26,6 +26,7 @@
 | Tool | Description |
 |------|-------------|
 | `search_cve` | Search all VulnCheck indices for a CVE ID. Returns matching records aggregated across advisories, exploits, threat intelligence, and vulnerability databases. Supports cursor-based pagination. |
+| `get_cve_affected_products` | Resolve a CVE ID to the software it affects: vendor/product pairs with vulnerable version ranges and CPE part, projected from both NIST's `configurations` and VulnCheck's `vcConfigurations`, with each entry attributed to its source. Prefer this over `search_cve` for "what does this CVE affect": `search_cve` returns a page ranked across all indices and usually omits the NVD record that carries the configurations. |
 
 ## CPE & PURL
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,6 +23,7 @@ type Client interface {
 	IdentifyComponent(ctx context.Context, vendor, product, version string) ([]IdentifyResult, error)
 	GetRules(ctx context.Context, ruleType string) (string, error)
 	SearchCVE(ctx context.Context, q SearchCVEQuery) (*SearchCVEResult, error)
+	GetCVEAffectedProducts(ctx context.Context, cve string) (*CVEAffectedResult, error)
 	SearchDocs(ctx context.Context) (string, error)
 	GetDoc(ctx context.Context, docURL string) (string, error)
 	// V4 Endpoints

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -3,3 +3,5 @@ package client
 import "errors"
 
 var ErrNoIndexArg = errors.New("no index argument")
+
+var ErrNoCVEArg = errors.New("no cve argument")

--- a/internal/client/get_cve_affected_products.go
+++ b/internal/client/get_cve_affected_products.go
@@ -1,0 +1,336 @@
+package client
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// cveAffectedIndex holds the NVD documents this tool projects. It carries both
+// NIST's configurations and VulnCheck's own vcConfigurations, and nist-nvd2 was
+// observed to serve byte-identical content for both fields, so querying that as a
+// fallback cost a round trip without adding data.
+const cveAffectedIndex = "vulncheck-nvd2"
+
+// The two configuration sets disagree on vendor strings: CVE-2024-6387 is
+// openbsd/openssh to NIST and openssh/openssh to VulnCheck. Vendor/product
+// de-duplication cannot collapse that, so each entry names where it came from
+// rather than presenting one spelling as the answer.
+const (
+	sourceNVD       = "nvd"
+	sourceVulnCheck = "vulncheck"
+)
+
+// maxAffectedEntries bounds each projected list. Most CVEs name a handful of
+// products, but speculative-execution bugs and similar enumerate several hundred,
+// and the purpose of this tool is a response that always fits in a model's context.
+const maxAffectedEntries = 100
+
+// AffectedProduct is a vendor/product pair with the version ranges a CVE applies to.
+type AffectedProduct struct {
+	// Part is the CPE part: "a" application, "o" operating system, "h" hardware.
+	// Keeping it saves a caller inferring whether an entry is software or a device.
+	Part     string   `json:"part,omitempty"`
+	Vendor   string   `json:"vendor"`
+	Product  string   `json:"product"`
+	Versions []string `json:"versions"`
+	// Sources names the configuration sets this entry appears in, so a NIST vendor
+	// spelling can be told from a VulnCheck one.
+	Sources []string `json:"sources"`
+}
+
+// CVEAffectedResult projects an NVD document down to the software it names. The
+// source documents reach hundreds of kilobytes; only these coordinates are returned.
+type CVEAffectedResult struct {
+	CVE      string            `json:"cve"`
+	Products []AffectedProduct `json:"affected_products"`
+	// Platforms holds entries an AND configuration marks vulnerable:false, the
+	// environment a vulnerable component runs on rather than the component itself.
+	// Keeping them out of Products stops the host OS being reported as the thing to
+	// patch, while still answering "where does this apply".
+	Platforms []AffectedProduct `json:"platforms,omitempty"`
+	// The totals are always the true counts. Truncated reports whether either list
+	// was cut to maxAffectedEntries, so a shortened list is never mistaken for a
+	// complete one.
+	TotalProducts  int  `json:"total_affected_products"`
+	TotalPlatforms int  `json:"total_platforms,omitempty"`
+	Truncated      bool `json:"truncated,omitempty"`
+	// SkippedCriteria counts match rules that could not be parsed. A projection is
+	// only worth trusting if it admits what it dropped.
+	SkippedCriteria int `json:"skipped_criteria,omitempty"`
+	// Note explains an empty result, so a caller can tell "nothing is affected" from
+	// "this CVE carries no CPE data" - very different answers to the same question.
+	Note string `json:"note,omitempty"`
+}
+
+const (
+	noConfigurationsNote = "neither NIST's configurations nor VulnCheck's vcConfigurations are populated for this " +
+		"CVE, so no affected products can be derived; package-ecosystem advisories (npm, PyPI, Go) commonly carry none"
+	noUsableCriteriaNote = "CPE configurations are published for this CVE but none of them yielded a product; " +
+		"any unparsable match rules are counted in skipped_criteria"
+)
+
+// nvdCPEMatch is one CPE match rule. NVD expresses applicability either through the
+// version field of the CPE string or through the four optional range bounds.
+type nvdCPEMatch struct {
+	Vulnerable            bool   `json:"vulnerable"`
+	Criteria              string `json:"criteria"`
+	VersionStartIncluding string `json:"versionStartIncluding"`
+	VersionStartExcluding string `json:"versionStartExcluding"`
+	VersionEndIncluding   string `json:"versionEndIncluding"`
+	VersionEndExcluding   string `json:"versionEndExcluding"`
+}
+
+// nvdNode groups match rules. NVD 2.0 nodes do not nest: an AND configuration is
+// expressed as sibling nodes under one configuration, each holding one side of the
+// pairing, so reading a configuration's nodes flatly covers it.
+type nvdNode struct {
+	// Negate inverts the node's match, so nothing under it is affirmatively affected.
+	Negate   bool          `json:"negate"`
+	CPEMatch []nvdCPEMatch `json:"cpeMatch"`
+}
+
+type nvdConfiguration struct {
+	// Negate inverts the whole configuration, as above.
+	Negate bool      `json:"negate"`
+	Nodes  []nvdNode `json:"nodes"`
+}
+
+// nvdDocument holds both configuration sets. NIST leaves configurations unpopulated
+// on CVEs it has not analysed, and for those VulnCheck's own set is usually the only
+// CPE data there is, so both have to be read.
+type nvdDocument struct {
+	Configurations   []nvdConfiguration `json:"configurations"`
+	VCConfigurations []nvdConfiguration `json:"vcConfigurations"`
+}
+
+type productKey struct {
+	part    string
+	vendor  string
+	product string
+}
+
+// productEntry collects everything seen for one product key across both sources.
+type productEntry struct {
+	versions map[string]struct{}
+	sources  map[string]struct{}
+}
+
+// cpeAccumulator de-duplicates match rules into vendor/product pairs. A CVE commonly
+// repeats the same product across many configurations, once per platform pairing.
+type cpeAccumulator struct {
+	vulnerable map[productKey]*productEntry
+	platforms  map[productKey]*productEntry
+	skipped    int
+}
+
+func newCPEAccumulator() *cpeAccumulator {
+	return &cpeAccumulator{
+		vulnerable: map[productKey]*productEntry{},
+		platforms:  map[productKey]*productEntry{},
+	}
+}
+
+// walk records every match rule in one configuration set, attributing what it finds
+// to source. Negated scopes are skipped rather than reported inverted.
+func (a *cpeAccumulator) walk(configurations []nvdConfiguration, source string) {
+	for _, configuration := range configurations {
+		if configuration.Negate {
+			continue
+		}
+		for _, node := range configuration.Nodes {
+			if node.Negate {
+				continue
+			}
+			for _, match := range node.CPEMatch {
+				part, vendor, product, version, ok := parseCPE(match.Criteria)
+				if !ok {
+					a.skipped++
+					continue
+				}
+				target := a.platforms
+				if match.Vulnerable {
+					target = a.vulnerable
+				}
+				key := productKey{part: part, vendor: vendor, product: product}
+				entry := target[key]
+				if entry == nil {
+					entry = &productEntry{
+						versions: map[string]struct{}{},
+						sources:  map[string]struct{}{},
+					}
+					target[key] = entry
+				}
+				entry.versions[versionRange(match, version)] = struct{}{}
+				entry.sources[source] = struct{}{}
+			}
+		}
+	}
+}
+
+// parseCPE pulls part, vendor, product, and version out of a CPE 2.3 formatted
+// string, whose fields are colon-separated as
+// cpe:2.3:<part>:<vendor>:<product>:<version>:...
+func parseCPE(criteria string) (part, vendor, product, version string, ok bool) {
+	fields := splitCPE(criteria)
+	if len(fields) < 6 {
+		return "", "", "", "", false
+	}
+	return unescapeCPE(fields[2]), unescapeCPE(fields[3]), unescapeCPE(fields[4]), unescapeCPE(fields[5]), true
+}
+
+// splitCPE splits on the colons that separate fields, ignoring any a field escaped
+// for itself. Without this an escaped colon shifts every later field by one.
+func splitCPE(criteria string) []string {
+	var fields []string
+	start := 0
+	for i := 0; i < len(criteria); i++ {
+		if criteria[i] != ':' || (i > 0 && criteria[i-1] == '\\') {
+			continue
+		}
+		fields = append(fields, criteria[start:i])
+		start = i + 1
+	}
+	return append(fields, criteria[start:])
+}
+
+// unescapeCPE drops the backslashes CPE 2.3 requires ahead of punctuation, so a
+// version reads as 15.2(5)e rather than 15.2\(5\)e. Note this is the opposite of the
+// CLI's unbindValueFS, which produces the quoted well-formed name and keeps them.
+func unescapeCPE(field string) string {
+	if !strings.Contains(field, `\`) {
+		return field
+	}
+	var out strings.Builder
+	out.Grow(len(field))
+	for i := 0; i < len(field); i++ {
+		if field[i] == '\\' && i+1 < len(field) {
+			i++
+		}
+		out.WriteByte(field[i])
+	}
+	return out.String()
+}
+
+// versionRange renders a match rule as a readable constraint. With no range bounds
+// set, the version lives in the CPE string itself, where "*" and "-" mean every
+// version.
+func versionRange(match nvdCPEMatch, version string) string {
+	var bounds []string
+	switch {
+	case match.VersionStartIncluding != "":
+		bounds = append(bounds, ">="+match.VersionStartIncluding)
+	case match.VersionStartExcluding != "":
+		bounds = append(bounds, ">"+match.VersionStartExcluding)
+	}
+	switch {
+	case match.VersionEndIncluding != "":
+		bounds = append(bounds, "<="+match.VersionEndIncluding)
+	case match.VersionEndExcluding != "":
+		bounds = append(bounds, "<"+match.VersionEndExcluding)
+	}
+	if len(bounds) > 0 {
+		return strings.Join(bounds, " ")
+	}
+	if version == "" || version == "*" || version == "-" {
+		return "all versions"
+	}
+	return version
+}
+
+// flatten renders the accumulator into a stably ordered slice, so the same CVE
+// always projects to the same output.
+func flatten(entries map[productKey]*productEntry) []AffectedProduct {
+	out := make([]AffectedProduct, 0, len(entries))
+	for key, entry := range entries {
+		out = append(out, AffectedProduct{
+			Part:     key.part,
+			Vendor:   key.vendor,
+			Product:  key.product,
+			Versions: sortedKeys(entry.versions),
+			Sources:  sortedKeys(entry.sources),
+		})
+	}
+	slices.SortFunc(out, func(a, b AffectedProduct) int {
+		if c := cmp.Compare(a.Vendor, b.Vendor); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Product, b.Product); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Part, b.Part)
+	})
+	return out
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// GetCVEAffectedProducts resolves a CVE to the software it affects by projecting the
+// NVD document's CPE configurations down to vendor/product/version coordinates. The
+// document itself is never returned: it is routinely large enough to exhaust a
+// model's context on its own, while the coordinates it contains are small.
+func (c *VulncheckClient) GetCVEAffectedProducts(ctx context.Context, cve string) (*CVEAffectedResult, error) {
+	if cve == "" {
+		return nil, ErrNoCVEArg
+	}
+
+	result := &CVEAffectedResult{CVE: cve, Products: []AffectedProduct{}}
+
+	// One document carries the CVE's complete configuration set, so a limit of one
+	// is sufficient.
+	res, err := c.SearchIndex(ctx, SearchIndexQuery{Index: cveAffectedIndex, CVE: cve, Limit: 1})
+	if err != nil {
+		return nil, fmt.Errorf("querying index %q for %s: %w", cveAffectedIndex, cve, err)
+	}
+	if len(res.Data) == 0 {
+		result.Note = noConfigurationsNote
+		return result, nil
+	}
+
+	var doc nvdDocument
+	if err := json.Unmarshal(res.Data[0], &doc); err != nil {
+		return nil, fmt.Errorf("decoding %q document for %s: %w", cveAffectedIndex, cve, err)
+	}
+	if len(doc.Configurations) == 0 && len(doc.VCConfigurations) == 0 {
+		result.Note = noConfigurationsNote
+		return result, nil
+	}
+
+	acc := newCPEAccumulator()
+	acc.walk(doc.Configurations, sourceNVD)
+	acc.walk(doc.VCConfigurations, sourceVulnCheck)
+
+	setAffected(result, flatten(acc.vulnerable), flatten(acc.platforms), acc.skipped)
+	if len(result.Products) == 0 && len(result.Platforms) == 0 {
+		result.Note = noUsableCriteriaNote
+	}
+	return result, nil
+}
+
+// setAffected fills the result's lists and true totals, truncating each list to
+// maxAffectedEntries.
+func setAffected(result *CVEAffectedResult, products, platforms []AffectedProduct, skipped int) {
+	result.TotalProducts = len(products)
+	result.TotalPlatforms = len(platforms)
+	result.SkippedCriteria = skipped
+	if len(products) > maxAffectedEntries {
+		products = products[:maxAffectedEntries]
+		result.Truncated = true
+	}
+	if len(platforms) > maxAffectedEntries {
+		platforms = platforms[:maxAffectedEntries]
+		result.Truncated = true
+	}
+	result.Products = products
+	result.Platforms = platforms
+}

--- a/internal/client/get_cve_affected_products_test.go
+++ b/internal/client/get_cve_affected_products_test.go
@@ -1,0 +1,372 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// indexDoc wraps documents the way /v3/index/{name} does.
+func indexDoc(docs ...any) map[string]any {
+	return map[string]any{
+		"_meta": map[string]any{"total_documents": len(docs)},
+		"data":  docs,
+	}
+}
+
+func cpeMatch(vulnerable bool, criteria string, extra map[string]any) map[string]any {
+	m := map[string]any{"vulnerable": vulnerable, "criteria": criteria}
+	maps.Copy(m, extra)
+	return m
+}
+
+// node builds one configuration node holding the given match rules.
+func node(matches ...any) map[string]any {
+	return map[string]any{"cpeMatch": matches}
+}
+
+// config builds one configuration holding the given nodes.
+func config(nodes ...any) map[string]any {
+	return map[string]any{"nodes": nodes}
+}
+
+// newIndexTestServer serves one canned response per index name, so a test can also
+// assert which index was asked.
+func newIndexTestServer(t *testing.T, byIndex map[string]any, status map[string]int) *VulncheckClient {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := strings.TrimPrefix(r.URL.Path, "/v3/index/")
+		if code, ok := status[key]; ok && code != http.StatusOK {
+			w.WriteHeader(code)
+			_, _ = fmt.Fprint(w, "failure")
+			return
+		}
+		if body, ok := byIndex[key]; ok {
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(indexDoc())
+	}))
+	t.Cleanup(srv.Close)
+
+	return &VulncheckClient{
+		http:      srv.Client(),
+		baseURL:   srv.URL,
+		token:     "test-token",
+		userAgent: "vulncheck-mcp/test",
+	}
+}
+
+// byProduct indexes a projection by product name for order-independent assertions.
+func byProduct(products []AffectedProduct) map[string]AffectedProduct {
+	out := make(map[string]AffectedProduct, len(products))
+	for _, p := range products {
+		out[p.Product] = p
+	}
+	return out
+}
+
+func TestGetCVEAffectedProducts(t *testing.T) {
+	t.Run("splits vulnerable products from AND-configuration platforms", func(t *testing.T) {
+		// Shaped after CVE-2026-22561: an AND configuration carries the vulnerable
+		// application in one node and the host OS in a sibling node.
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"id": "CVE-2026-22561",
+				"configurations": []any{map[string]any{
+					"operator": "AND",
+					"nodes": []any{
+						node(cpeMatch(
+							true, "cpe:2.3:a:anthropic:claude:*:*:*:*:*:*:*:*",
+							map[string]any{"versionEndExcluding": "1.1.3363"},
+						)),
+						node(cpeMatch(
+							false, "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*", nil,
+						)),
+					},
+				}},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2026-22561")
+		require.NoError(t, err)
+
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, "anthropic", result.Products[0].Vendor)
+		assert.Equal(t, "claude", result.Products[0].Product)
+		assert.Equal(t, "a", result.Products[0].Part)
+		assert.Equal(t, []string{"<1.1.3363"}, result.Products[0].Versions)
+		assert.Equal(t, []string{sourceNVD}, result.Products[0].Sources)
+
+		require.Len(t, result.Platforms, 1)
+		assert.Equal(t, "microsoft", result.Platforms[0].Vendor)
+		assert.Equal(t, "windows", result.Platforms[0].Product)
+		assert.Equal(t, "o", result.Platforms[0].Part, "the platform is an OS, not an application")
+
+		assert.Equal(t, 1, result.TotalProducts)
+		assert.False(t, result.Truncated)
+		assert.Empty(t, result.Note)
+	})
+
+	t.Run("reads vcConfigurations when configurations is absent", func(t *testing.T) {
+		// CVE-2025-7195's real shape: NIST has not analysed it, so the document
+		// carries no configurations key at all and VulnCheck's set is the only data.
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"id": "CVE-2025-7195",
+				"vcConfigurations": []any{
+					config(node(cpeMatch(true, "cpe:2.3:a:redhat:keycloak:-:*:*:*:*:*:*:*", nil))),
+				},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2025-7195")
+		require.NoError(t, err)
+
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, "redhat", result.Products[0].Vendor)
+		assert.Equal(t, "keycloak", result.Products[0].Product)
+		assert.Equal(t, []string{"all versions"}, result.Products[0].Versions)
+		assert.Equal(t, []string{sourceVulnCheck}, result.Products[0].Sources)
+		assert.Empty(t, result.Note, "configuration data exists, so nothing should claim otherwise")
+	})
+
+	t.Run("attributes a product each source spells differently", func(t *testing.T) {
+		// CVE-2024-6387: openbsd/openssh to NIST, openssh/openssh to VulnCheck.
+		// Vendor/product de-duplication cannot merge these, so both must be labelled.
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{
+					config(node(cpeMatch(true, "cpe:2.3:a:openbsd:openssh:9.6:*:*:*:*:*:*:*", nil))),
+				},
+				"vcConfigurations": []any{
+					config(node(cpeMatch(true, "cpe:2.3:a:openssh:openssh:9.6:*:*:*:*:*:*:*", nil))),
+				},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2024-6387")
+		require.NoError(t, err)
+
+		require.Len(t, result.Products, 2)
+		assert.Equal(t, "openbsd", result.Products[0].Vendor)
+		assert.Equal(t, []string{sourceNVD}, result.Products[0].Sources)
+		assert.Equal(t, "openssh", result.Products[1].Vendor)
+		assert.Equal(t, []string{sourceVulnCheck}, result.Products[1].Sources)
+	})
+
+	t.Run("merges a product both sources agree on, naming both", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{
+					config(node(cpeMatch(true, "cpe:2.3:a:v:agreed:1.0:*:*:*:*:*:*:*", nil))),
+				},
+				"vcConfigurations": []any{
+					config(node(cpeMatch(true, "cpe:2.3:a:v:agreed:2.0:*:*:*:*:*:*:*", nil))),
+				},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00009")
+		require.NoError(t, err)
+
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, []string{"1.0", "2.0"}, result.Products[0].Versions)
+		assert.Equal(t, []string{sourceNVD, sourceVulnCheck}, result.Products[0].Sources)
+	})
+
+	t.Run("renders version bounds and wildcards", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{config(node(
+					cpeMatch(true, "cpe:2.3:a:v:ranged:*:*:*:*:*:*:*:*", map[string]any{
+						"versionStartIncluding": "2.0", "versionEndExcluding": "2.5",
+					}),
+					cpeMatch(true, "cpe:2.3:a:v:exclusive:*:*:*:*:*:*:*:*", map[string]any{
+						"versionStartExcluding": "1.0", "versionEndIncluding": "1.9",
+					}),
+					cpeMatch(true, "cpe:2.3:a:v:wildcard:*:*:*:*:*:*:*:*", nil),
+					cpeMatch(true, "cpe:2.3:a:v:pinned:3.1.4:*:*:*:*:*:*:*", nil),
+				))},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00002")
+		require.NoError(t, err)
+
+		got := byProduct(result.Products)
+		assert.Equal(t, []string{">=2.0 <2.5"}, got["ranged"].Versions)
+		assert.Equal(t, []string{">1.0 <=1.9"}, got["exclusive"].Versions)
+		assert.Equal(t, []string{"all versions"}, got["wildcard"].Versions)
+		assert.Equal(t, []string{"3.1.4"}, got["pinned"].Versions)
+	})
+
+	t.Run("unescapes punctuation in CPE values", func(t *testing.T) {
+		// CVE-2018-0171's real version string. Common on Cisco and Juniper records.
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{config(node(
+					cpeMatch(true, "cpe:2.3:o:cisco:ios:15.2\\(5\\)e:*:*:*:*:*:*:*", nil),
+				))},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2018-0171")
+		require.NoError(t, err)
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, []string{"15.2(5)e"}, result.Products[0].Versions)
+	})
+
+	t.Run("an escaped colon does not shift the fields after it", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{config(node(
+					cpeMatch(true, "cpe:2.3:a:v:p:1.0\\:beta:*:*:*:*:*:*:*", nil),
+				))},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00010")
+		require.NoError(t, err)
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, "v", result.Products[0].Vendor)
+		assert.Equal(t, "p", result.Products[0].Product)
+		assert.Equal(t, []string{"1.0:beta"}, result.Products[0].Versions)
+	})
+
+	t.Run("negated scopes are not reported as affected", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{
+					map[string]any{
+						"negate": true,
+						"nodes":  []any{node(cpeMatch(true, "cpe:2.3:a:v:negated-config:1.0:*:*:*:*:*:*:*", nil))},
+					},
+					config(
+						map[string]any{
+							"negate":   true,
+							"cpeMatch": []any{cpeMatch(true, "cpe:2.3:a:v:negated-node:1.0:*:*:*:*:*:*:*", nil)},
+						},
+						node(cpeMatch(true, "cpe:2.3:a:v:kept:1.0:*:*:*:*:*:*:*", nil)),
+					),
+				},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00011")
+		require.NoError(t, err)
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, "kept", result.Products[0].Product)
+	})
+
+	t.Run("de-duplicates a product repeated across configurations", func(t *testing.T) {
+		repeated := config(node(cpeMatch(true, "cpe:2.3:a:v:p:1.0:*:*:*:*:*:*:*", nil)))
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{repeated, repeated},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00003")
+		require.NoError(t, err)
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, []string{"1.0"}, result.Products[0].Versions)
+	})
+
+	t.Run("both configuration sets empty returns an explanatory note", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"id": "CVE-2099-99999", "configurations": nil, "vcConfigurations": nil,
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-99999")
+		require.NoError(t, err)
+		assert.Empty(t, result.Products)
+		assert.NotNil(t, result.Products, "empty list must serialize as [] rather than null")
+		assert.Contains(t, result.Note, "vcConfigurations",
+			"the note must say which sources were checked")
+	})
+
+	t.Run("no document for the CVE returns the same note", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{"vulncheck-nvd2": indexDoc()}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00012")
+		require.NoError(t, err)
+		assert.Empty(t, result.Products)
+		assert.NotEmpty(t, result.Note)
+	})
+
+	t.Run("counts criteria it could not parse", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{config(node(
+					cpeMatch(true, "not-a-cpe", nil),
+					cpeMatch(true, "cpe:2.3:a:truncated", nil),
+					cpeMatch(true, "cpe:2.3:a:good:product:1.0:*:*:*:*:*:*:*", nil),
+				))},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00008")
+		require.NoError(t, err)
+		require.Len(t, result.Products, 1)
+		assert.Equal(t, "good", result.Products[0].Vendor)
+		assert.Equal(t, 2, result.SkippedCriteria)
+	})
+
+	t.Run("configurations present but nothing usable says so", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{config(node(cpeMatch(true, "not-a-cpe", nil)))},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00013")
+		require.NoError(t, err)
+		assert.Empty(t, result.Products)
+		assert.Equal(t, 1, result.SkippedCriteria)
+		assert.Contains(t, result.Note, "skipped_criteria")
+	})
+
+	t.Run("truncates past the cap but reports the true total", func(t *testing.T) {
+		matches := make([]any, 0, maxAffectedEntries+10)
+		for i := range maxAffectedEntries + 10 {
+			matches = append(matches, cpeMatch(true,
+				fmt.Sprintf("cpe:2.3:a:vendor%03d:product:1.0:*:*:*:*:*:*:*", i), nil))
+		}
+		vc := newIndexTestServer(t, map[string]any{
+			"vulncheck-nvd2": indexDoc(map[string]any{
+				"configurations": []any{config(node(matches...))},
+			}),
+		}, nil)
+
+		result, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00005")
+		require.NoError(t, err)
+		assert.Len(t, result.Products, maxAffectedEntries)
+		assert.Equal(t, maxAffectedEntries+10, result.TotalProducts)
+		assert.True(t, result.Truncated)
+	})
+
+	t.Run("an index failure is reported rather than read as no data", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{"vulncheck-nvd2": indexDoc()},
+			map[string]int{"vulncheck-nvd2": http.StatusUnauthorized})
+
+		_, err := vc.GetCVEAffectedProducts(t.Context(), "CVE-2099-00007")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, cveAffectedIndex)
+	})
+
+	t.Run("empty cve is rejected", func(t *testing.T) {
+		vc := newIndexTestServer(t, map[string]any{}, nil)
+		_, err := vc.GetCVEAffectedProducts(t.Context(), "")
+		require.ErrorIs(t, err, ErrNoCVEArg)
+	})
+}

--- a/internal/server/get_cve_affected_products.go
+++ b/internal/server/get_cve_affected_products.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/vulncheck-oss/mcp/internal/client"
+)
+
+type getCVEAffectedProductsArgs struct {
+	CVE string `json:"cve" jsonschema:"required,CVE ID to resolve to affected software, e.g. 'CVE-2021-44228'"`
+}
+
+var GetCVEAffectedProductsTool = &mcp.Tool{
+	Name:  "get_cve_affected_products",
+	Title: "Get CVE Affected Products",
+	Description: "Resolve a CVE ID to the software it affects: vendor and product pairs with the vulnerable version ranges, extracted from NVD CPE configurations. " +
+		"Use this for any question about which products, vendors, or versions a CVE affects. search_cve does not answer it: it returns a page of the highest-scoring records across every index, " +
+		"which for CVE-2024-21762 is 10 of 182 hits and includes none of the NVD records that carry the configurations. " +
+		"Entries a configuration marks non-vulnerable are reported separately as platforms, meaning the environment a vulnerable component runs on rather than the component to patch. " +
+		"Each entry names the sources it came from, since NIST and VulnCheck sometimes spell the same vendor differently. " +
+		"When a CVE carries no CPE data at all, common for package-ecosystem advisories (npm, PyPI, Go), the response says so in a note rather than returning a bare empty list.",
+	Annotations: &mcp.ToolAnnotations{
+		ReadOnlyHint: true,
+	},
+}
+
+func registerGetCVEAffectedProducts(srv *mcp.Server, vc client.Client) {
+	mcp.AddTool(srv, GetCVEAffectedProductsTool, MakeGetCVEAffectedProductsHandler(vc))
+}
+
+func MakeGetCVEAffectedProductsHandler(vc client.Client) mcp.ToolHandlerFor[getCVEAffectedProductsArgs, any] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args getCVEAffectedProductsArgs) (*mcp.CallToolResult, any, error) {
+		result, err := vc.GetCVEAffectedProducts(ctx, args.CVE)
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting affected products: %w", err)
+		}
+
+		out, err := json.Marshal(result)
+		if err != nil {
+			return nil, nil, fmt.Errorf("serializing results: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(out)}},
+		}, nil, nil
+	}
+}

--- a/internal/server/get_cve_affected_products_test.go
+++ b/internal/server/get_cve_affected_products_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulncheck-oss/mcp/internal/client"
+)
+
+// jsonInt reads a count out of a decoded payload. JSON numbers decode to float64,
+// but these are exact integer counts, so they are compared as ints.
+func jsonInt(t *testing.T, payload map[string]any, key string) int {
+	t.Helper()
+	raw, ok := payload[key].(float64)
+	require.True(t, ok, "expected %q to be a number", key)
+	return int(raw)
+}
+
+func TestMakeGetCVEAffectedProductsHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       getCVEAffectedProductsArgs
+		clientResp *client.CVEAffectedResult
+		clientErr  error
+		wantErr    bool
+		assertJSON func(t *testing.T, payload map[string]any)
+	}{
+		{
+			name: "returns products and platforms",
+			args: getCVEAffectedProductsArgs{CVE: "CVE-2026-22561"},
+			clientResp: &client.CVEAffectedResult{
+				CVE: "CVE-2026-22561",
+				Products: []client.AffectedProduct{{
+					Part: "a", Vendor: "anthropic", Product: "claude",
+					Versions: []string{"<1.1.3363"}, Sources: []string{"nvd"},
+				}},
+				Platforms: []client.AffectedProduct{{
+					Part: "o", Vendor: "microsoft", Product: "windows", Sources: []string{"nvd"},
+				}},
+				TotalProducts:  1,
+				TotalPlatforms: 1,
+			},
+			assertJSON: func(t *testing.T, payload map[string]any) {
+				t.Helper()
+				products, ok := payload["affected_products"].([]any)
+				require.True(t, ok)
+				require.Len(t, products, 1)
+				first, ok := products[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "anthropic", first["vendor"])
+				assert.Equal(t, "claude", first["product"])
+				assert.Equal(t, "a", first["part"])
+				assert.Equal(t, []any{"nvd"}, first["sources"],
+					"per-entry attribution must survive serialization")
+				assert.Equal(t, 1, jsonInt(t, payload, "total_affected_products"))
+				assert.Contains(t, payload, "platforms")
+			},
+		},
+		{
+			name: "note survives serialization when nothing is affected",
+			args: getCVEAffectedProductsArgs{CVE: "CVE-2025-59532"},
+			clientResp: &client.CVEAffectedResult{
+				CVE:      "CVE-2025-59532",
+				Products: []client.AffectedProduct{},
+				Note:     "no CPE configurations are published for this CVE",
+			},
+			assertJSON: func(t *testing.T, payload map[string]any) {
+				t.Helper()
+				assert.Empty(t, payload["affected_products"])
+				assert.Contains(t, payload["note"], "no CPE configurations")
+			},
+		},
+		{
+			name: "truncation flag is exposed to the caller",
+			args: getCVEAffectedProductsArgs{CVE: "CVE-2018-3639"},
+			clientResp: &client.CVEAffectedResult{
+				CVE:           "CVE-2018-3639",
+				Products:      []client.AffectedProduct{{Vendor: "v", Product: "p"}},
+				TotalProducts: 282,
+				Truncated:     true,
+			},
+			assertJSON: func(t *testing.T, payload map[string]any) {
+				t.Helper()
+				assert.Equal(t, true, payload["truncated"])
+				assert.Equal(t, 282, jsonInt(t, payload, "total_affected_products"))
+			},
+		},
+		{
+			name:      "client error propagates",
+			args:      getCVEAffectedProductsArgs{CVE: "CVE-2099-99999"},
+			clientErr: errors.New("index unreachable"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotCVE string
+
+			mock := &mockClient{
+				getCVEAffectedFn: func(_ context.Context, cve string) (*client.CVEAffectedResult, error) {
+					gotCVE = cve
+					return tt.clientResp, tt.clientErr
+				},
+			}
+
+			handler := MakeGetCVEAffectedProductsHandler(mock)
+			result, _, err := handler(context.Background(), nil, tt.args)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.args.CVE, gotCVE)
+
+			require.Len(t, result.Content, 1)
+			text, ok := result.Content[0].(*mcp.TextContent)
+			require.True(t, ok)
+
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal([]byte(text.Text), &payload))
+			assert.Equal(t, tt.args.CVE, payload["cve"])
+
+			if tt.assertJSON != nil {
+				tt.assertJSON(t, payload)
+			}
+		})
+	}
+}

--- a/internal/server/mock_test.go
+++ b/internal/server/mock_test.go
@@ -24,6 +24,7 @@ type mockClient struct {
 	listAdvisoryBackupsFn func(ctx context.Context) ([]vulncheck.BackupFeedItem, error)
 	getAdvisoryBackupFn   func(ctx context.Context, name string) (*vulncheck.BackupBackupResponse, error)
 	searchCVEFn           func(ctx context.Context, q client.SearchCVEQuery) (*client.SearchCVEResult, error)
+	getCVEAffectedFn      func(ctx context.Context, cve string) (*client.CVEAffectedResult, error)
 	searchDocsFn          func(ctx context.Context) (string, error)
 	getDocFn              func(ctx context.Context, url string) (string, error)
 }
@@ -90,6 +91,10 @@ func (m *mockClient) GetAdvisoryBackup(ctx context.Context, name string) (*vulnc
 
 func (m *mockClient) SearchCVE(ctx context.Context, q client.SearchCVEQuery) (*client.SearchCVEResult, error) {
 	return m.searchCVEFn(ctx, q)
+}
+
+func (m *mockClient) GetCVEAffectedProducts(ctx context.Context, cve string) (*client.CVEAffectedResult, error) {
+	return m.getCVEAffectedFn(ctx, cve)
 }
 
 func (m *mockClient) SearchDocs(ctx context.Context) (string, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ var tools = []func(*mcp.Server, client.Client){
 	registerGetRules,
 	// v3/search/cve
 	registerSearchCVE,
+	registerGetCVEAffectedProducts,
 	// docs
 	registerSearchDocs,
 	registerGetDoc,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -37,4 +37,5 @@ func TestNewServer_ToolsRegistered(t *testing.T) {
 	assert.Contains(t, names, "search_index")
 	assert.Contains(t, names, "get_cpe_cves")
 	assert.Contains(t, names, "search_cpe")
+	assert.Contains(t, names, "get_cve_affected_products")
 }


### PR DESCRIPTION
Closes #41

## Changes

New `get_cve_affected_products` tool. Given a CVE ID it returns the vendors, products, CPE parts, and version ranges the CVE affects, projected from the NVD document's CPE configurations. The document itself is never returned: it reaches 880 KB on CVEs like Log4Shell, while the coordinates in it are small.

- **Reads both configuration sets.** NIST leaves `configurations` unpopulated on CVEs it has not analysed, and for those VulnCheck's `vcConfigurations` is the only CPE data there is. In a sample of 800 recent `vulncheck-nvd2` documents, 279 (35%) had an empty or absent `configurations` with a populated `vcConfigurations`.
- **Attributes every entry to its source.** The two sets disagree on vendor strings: CVE-2024-6387 is `openbsd/openssh` to NIST and `openssh/openssh` to VulnCheck, with VulnCheck carrying the tighter range. Vendor/product de-duplication cannot collapse that, so each entry carries a `sources` list rather than one spelling being presented as the answer.
- **Splits platforms from products.** Entries an AND configuration marks `vulnerable: false` are returned separately as `platforms`, so the host OS is not reported as the thing to patch.
- **Honours `negate`.** A negated configuration or node inverts its match, so nothing under one is claimed as affected.
- **Unescapes CPE values,** so a version reads `15.2(5)e` rather than `15.2\(5\)e`, and splits fields on unescaped colons only so an escaped colon cannot shift later fields.
- **Admits what it dropped.** Unparsable match rules are counted in `skipped_criteria`, lists are capped at 100 entries with the true totals and a `truncated` flag, and a CVE with no CPE data returns a note naming the sources checked rather than a bare empty list.

One query to `vulncheck-nvd2` serves all of this. `nist-nvd2` was measured to return byte-identical `configurations` and the same `vcConfigurations`, so querying it as a fallback cost a round trip without adding data.

This fills the gap between `search_cve` (a page ranked across every index, which for CVE-2024-21762 is 10 of 182 hits and includes none of the NVD records carrying the configurations) and `search_cpe` / `get_cpe_cves` (which require the caller to already know the CPE).

## Testing

- 17 subtests across client and server covering both configuration sets, per-source attribution for both disagreeing and agreeing spellings, the AND-configuration platform split, negated configurations and nodes, unescaping, escaped-colon field alignment, version bound and wildcard rendering, dedupe, the cap and truncation reporting, skipped-criteria counting, both empty-result notes, and error propagation.
- Verified against the live API: CVE-2025-7195 resolves to `redhat/keycloak` from `vcConfigurations` alone, CVE-2018-0171 renders `15.2(5)e`, CVE-2024-6387 returns both openssh spellings each attributed, CVE-2026-22561 splits `anthropic/claude` from Windows as a platform, and CVE-2025-59532 returns the note.
- `gofmt`, `go vet`, `golangci-lint`, and `go test -race ./...` all clean.