### PR TITLE
fix(#42): Flags versionless PURLs in search_purls responses

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,7 +33,7 @@
 |------|-------------|
 | `get_cpe_cves` | Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. |
 | `search_cpe` | Search for CPEs by component fields (vendor, product, version, part) and return matching CPEs with their associated CVEs. |
-| `search_purls` | Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. PURLs must include a version — the API returns no findings for a versionless PURL, and the tool flags them in a note. |
+| `search_purls` | Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. Include a version in every PURL — version matching is skipped for a versionless PURL, so findings are incomplete and usually empty, and the tool flags them in a note. |
 | `identify_component` | Convert a vendor, product, and optional version into best-match CPE and PURL identifiers with confidence levels. |
 
 ## Advisories (v4)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,7 +33,7 @@
 |------|-------------|
 | `get_cpe_cves` | Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. |
 | `search_cpe` | Search for CPEs by component fields (vendor, product, version, part) and return matching CPEs with their associated CVEs. |
-| `search_purls` | Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. |
+| `search_purls` | Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. PURLs must include a version — the API returns no findings for a versionless PURL, and the tool flags them in a note. |
 | `identify_component` | Convert a vendor, product, and optional version into best-match CPE and PURL identifiers with confidence levels. |
 
 ## Advisories (v4)

--- a/internal/server/search_purls.go
+++ b/internal/server/search_purls.go
@@ -11,23 +11,24 @@ import (
 )
 
 type searchPURLsArgs struct {
-	PURLs []string `json:"purls" jsonschema:"Package URLs including a version, e.g. 'pkg:npm/@openai/codex@0.30.0' — the API returns findings only for fully versioned PURLs"`
+	PURLs []string `json:"purls" jsonschema:"Package URLs including a version, e.g. 'pkg:npm/@openai/codex@0.30.0' — findings are incomplete for a PURL without a version"`
 }
 
 var SearchPURLsTool = &mcp.Tool{
 	Name:  "search_purls",
 	Title: "Search Package URLs",
 	Description: "Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. " +
-		"PURLs must include a version (e.g. 'pkg:npm/@openai/codex@0.30.0'): the API silently returns no findings for a versionless PURL. " +
-		"For version-agnostic discovery use v4_search_advisory with package_name instead.",
+		"Include a version in every PURL (e.g. 'pkg:npm/@openai/codex@0.30.0'): version matching is skipped for a versionless PURL, so findings are " +
+		"incomplete and usually empty, and the tool flags them in a note. " +
+		"For version-agnostic discovery try v4_search_advisory with package_name, which matches package names exactly.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
 }
 
 // searchPURLsResponse wraps the client result so the handler can flag versionless
-// PURLs in-band: the backend answers them with an empty result, which otherwise
-// reads as "no known vulnerabilities".
+// PURLs in-band: the backend skips version matching for them, so the result is
+// empty or partial, which otherwise reads as "no known vulnerabilities".
 type searchPURLsResponse struct {
 	*client.SearchPURLsResult
 	Note string `json:"note,omitempty"`
@@ -65,9 +66,13 @@ func MakeSearchPURLsHandler(vc client.Client) mcp.ToolHandlerFor[searchPURLsArgs
 		}
 		if len(versionless) > 0 {
 			response.Note = fmt.Sprintf(
-				"no findings are ever returned for PURLs without a version: %s — append a version "+
-					"(e.g. 'pkg:npm/@openai/codex@0.30.0') or use v4_search_advisory with package_name "+
-					"for version-agnostic discovery; an empty result here does not mean the package has no known vulnerabilities",
+				"findings are incomplete for these PURLs because they name no version: %s — version "+
+					"matching is skipped, so language-ecosystem packages return nothing at all and OS "+
+					"packages return only issues that have no fix available. Append a version "+
+					"(e.g. 'pkg:npm/@openai/codex@0.30.0') for a complete answer; an empty or short "+
+					"result here does not mean the package has no known vulnerabilities. For "+
+					"version-agnostic discovery try v4_search_advisory with package_name, which "+
+					"matches package names exactly.",
 				strings.Join(versionless, ", "))
 		}
 

--- a/internal/server/search_purls.go
+++ b/internal/server/search_purls.go
@@ -4,22 +4,45 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/vulncheck-oss/mcp/internal/client"
 )
 
 type searchPURLsArgs struct {
-	PURLs []string `json:"purls" jsonschema:"Package URLs, e.g. 'pkg:hex/coherence@0.1.2'"`
+	PURLs []string `json:"purls" jsonschema:"Package URLs including a version, e.g. 'pkg:npm/@openai/codex@0.30.0' — the API returns findings only for fully versioned PURLs"`
 }
 
 var SearchPURLsTool = &mcp.Tool{
-	Name:        "search_purls",
-	Title:       "Search Package URLs",
-	Description: "Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details.",
+	Name:  "search_purls",
+	Title: "Search Package URLs",
+	Description: "Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. " +
+		"PURLs must include a version (e.g. 'pkg:npm/@openai/codex@0.30.0'): the API silently returns no findings for a versionless PURL. " +
+		"For version-agnostic discovery use v4_search_advisory with package_name instead.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
+}
+
+// searchPURLsResponse wraps the client result so the handler can flag versionless
+// PURLs in-band: the backend answers them with an empty result, which otherwise
+// reads as "no known vulnerabilities".
+type searchPURLsResponse struct {
+	*client.SearchPURLsResult
+	Note string `json:"note,omitempty"`
+}
+
+// purlLacksVersion reports whether a PURL names no version. The version follows an
+// "@" after the final path segment (a namespace such as "@openai" also starts with
+// "@", so earlier segments cannot be trusted).
+func purlLacksVersion(purl string) bool {
+	// Qualifiers and subpath follow the version and may themselves contain "/".
+	if i := strings.IndexAny(purl, "?#"); i >= 0 {
+		purl = purl[:i]
+	}
+	last := purl[strings.LastIndex(purl, "/")+1:]
+	return !strings.Contains(last, "@")
 }
 
 func registerSearchPURLs(srv *mcp.Server, vc client.Client) {
@@ -33,7 +56,22 @@ func MakeSearchPURLsHandler(vc client.Client) mcp.ToolHandlerFor[searchPURLsArgs
 			return nil, nil, fmt.Errorf("searching PURLs: %w", err)
 		}
 
-		out, err := json.Marshal(result)
+		response := searchPURLsResponse{SearchPURLsResult: result}
+		var versionless []string
+		for _, purl := range args.PURLs {
+			if purlLacksVersion(purl) {
+				versionless = append(versionless, purl)
+			}
+		}
+		if len(versionless) > 0 {
+			response.Note = fmt.Sprintf(
+				"no findings are ever returned for PURLs without a version: %s — append a version "+
+					"(e.g. 'pkg:npm/@openai/codex@0.30.0') or use v4_search_advisory with package_name "+
+					"for version-agnostic discovery; an empty result here does not mean the package has no known vulnerabilities",
+				strings.Join(versionless, ", "))
+		}
+
+		out, err := json.Marshal(response)
 		if err != nil {
 			return nil, nil, fmt.Errorf("serializing results: %w", err)
 		}

--- a/internal/server/search_purls_test.go
+++ b/internal/server/search_purls_test.go
@@ -89,3 +89,52 @@ func TestMakeSearchPURLsHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchPURLsVersionlessNote(t *testing.T) {
+	mock := &mockClient{
+		searchPURLsFn: func(_ context.Context, _ []string) (*client.SearchPURLsResult, error) {
+			return &client.SearchPURLsResult{Data: []v2.PurlBatchVulnFinding{}, Total: 0}, nil
+		},
+	}
+	handler := MakeSearchPURLsHandler(mock)
+
+	decode := func(t *testing.T, result *mcp.CallToolResult) searchPURLsResponse {
+		t.Helper()
+		var got searchPURLsResponse
+		got.SearchPURLsResult = &client.SearchPURLsResult{}
+		text := result.Content[0].(*mcp.TextContent).Text
+		require.NoError(t, json.Unmarshal([]byte(text), &got))
+		return got
+	}
+
+	t.Run("versionless purls are named in a note", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, searchPURLsArgs{
+			PURLs: []string{"pkg:npm/@openai/codex", "pkg:npm/@anthropic-ai/claude-code@1.0.0"},
+		})
+		require.NoError(t, err)
+
+		got := decode(t, result)
+		assert.Contains(t, got.Note, "pkg:npm/@openai/codex")
+		assert.NotContains(t, got.Note, "claude-code@1.0.0")
+	})
+
+	t.Run("fully versioned purls produce no note", func(t *testing.T) {
+		result, _, err := handler(context.Background(), nil, searchPURLsArgs{
+			PURLs: []string{"pkg:npm/@anthropic-ai/claude-code@1.0.0", "pkg:hex/coherence@0.1.2"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, decode(t, result).Note)
+	})
+}
+
+func TestPurlLacksVersion(t *testing.T) {
+	assert.True(t, purlLacksVersion("pkg:npm/@openai/codex"), "namespace @ must not count as a version")
+	assert.True(t, purlLacksVersion("pkg:npm/%40openai/codex"))
+	assert.True(t, purlLacksVersion("pkg:golang/github.com/gin-gonic/gin"))
+	assert.True(t, purlLacksVersion("pkg:npm/lodash?arch=x86"), "qualifiers are not a version")
+
+	assert.False(t, purlLacksVersion("pkg:npm/@openai/codex@0.30.0"))
+	assert.False(t, purlLacksVersion("pkg:npm/lodash@4.17.21"))
+	assert.False(t, purlLacksVersion("pkg:hex/coherence@0.1.2"))
+	assert.False(t, purlLacksVersion("pkg:npm/lodash@4.17.21?arch=x86#sub/path"))
+}

--- a/internal/server/search_purls_test.go
+++ b/internal/server/search_purls_test.go
@@ -108,13 +108,15 @@ func TestSearchPURLsVersionlessNote(t *testing.T) {
 	}
 
 	t.Run("versionless purls are named in a note", func(t *testing.T) {
+		// The versionless PURL must differ from the example the note itself cites,
+		// or the assertion below passes on that example alone.
 		result, _, err := handler(context.Background(), nil, searchPURLsArgs{
-			PURLs: []string{"pkg:npm/@openai/codex", "pkg:npm/@anthropic-ai/claude-code@1.0.0"},
+			PURLs: []string{"pkg:golang/github.com/gin-gonic/gin", "pkg:npm/@anthropic-ai/claude-code@1.0.0"},
 		})
 		require.NoError(t, err)
 
 		got := decode(t, result)
-		assert.Contains(t, got.Note, "pkg:npm/@openai/codex")
+		assert.Contains(t, got.Note, "pkg:golang/github.com/gin-gonic/gin")
 		assert.NotContains(t, got.Note, "claude-code@1.0.0")
 	})
 


### PR DESCRIPTION
Closes #42

## Changes

- `search_purls` now flags versionless PURLs in the response. Version matching does not apply to a PURL that names no version, so findings come back incomplete: language-ecosystem packages are matched on the full PURL string including the version and return nothing at all, while OS packages skip the version comparison for CVEs with no fix available and return only those. Both read as "no known vulnerabilities", so the handler adds a `note` naming the offending PURLs and stating what was actually skipped.
- The tool description and input schema state the version requirement, and point at `v4_search_advisory` with `package_name` for version-agnostic discovery, noting that it matches package names exactly.
- `purlLacksVersion` strips qualifiers and subpath before looking for the version separator, so a namespace `@` is not mistaken for a version and a subpath containing `/` does not defeat the check. Stripping qualifiers also matters for OS PURLs, where the distro qualifier trails the version.

## Testing

- New tests: versionless PURLs are named in a note, fully versioned PURLs produce none, and `purlLacksVersion` is checked across namespaced, URL-encoded, Go-style, qualified, and subpathed PURLs. The versionless PURL used in the note test is deliberately not a substring of the example the note itself cites, so the assertion cannot pass on that example alone.
- Verified against the live API: `pkg:deb/debian/openssl?distro=debian-12` returns 1 CVE versus 37 for the versioned PURL, and `pkg:npm/lodash` returns none versus 5 for `pkg:npm/lodash@4.17.20`.
- `gofmt`, `go vet`, `go test ./...` all clean.