### PR TITLE
fix: Recover v4 advisory vendor queries that silently returned nothing

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -31,7 +31,7 @@
 
 | Tool | Description |
 |------|-------------|
-| `get_cpe_cves` | Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. |
+| `get_cpe_cves` | Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. Any attribute accepts `*` and `?` wildcards, so a trailing wildcard on the product covers every product sharing that prefix in one call — prefer this over `search_cpe` when exploring a vendor, because `search_cpe` returns every matching CPE and its response can reach tens of megabytes. Wildcarding both vendor and product is unbounded and should be avoided. |
 | `search_cpe` | Search for CPEs by component fields (vendor, product, version, part) and return matching CPEs with their associated CVEs. |
 | `search_purls` | Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. |
 | `identify_component` | Convert a vendor, product, and optional version into best-match CPE and PURL identifiers with confidence levels. |
@@ -41,7 +41,7 @@
 | Tool | Description |
 |------|-------------|
 | `v4_list_advisories` | List all available VulnCheck advisory feeds. Call this first to discover which advisory names can be passed to `v4_search_advisory`. |
-| `v4_search_advisory` | Search VulnCheck v4 advisory feeds. Filter by advisory name, CVE ID, vendor, product, version, CPE, PURL, and more. Supports cursor-based pagination. |
+| `v4_search_advisory` | Search VulnCheck v4 advisory feeds. Filter by advisory name, CVE ID, vendor, product, version, CPE, PURL, and more. This is the tool that finds advisories carrying no CPE data, such as GHSA records for npm, PyPI and Go software — prefer it over the CPE tools for package-ecosystem products. Vendor and product are matched exactly and case-sensitively against the CNA-published strings; alternative capitalisations are retried automatically and an unmatchable product filter is dropped, with both explained in notes. |
 | `v4_list_advisory_backups` | List all VulnCheck v4 advisory backup feeds and their availability. Call this first to discover which feed names can be passed to `v4_get_advisory_backup`. |
 | `v4_get_advisory_backup` | Return pre-signed download URLs for a VulnCheck v4 advisory feed backup. |
 

--- a/internal/client/helpers_test.go
+++ b/internal/client/helpers_test.go
@@ -36,6 +36,18 @@ func jsonResp(status int, v any) *http.Response {
 	}
 }
 
+// newAPITestClient builds a client for the endpoints that issue their own HTTP
+// requests rather than going through the generated SDK, so the fake transport has
+// to sit on c.http instead of on the SDK configuration.
+func newAPITestClient(fn roundTripFunc) *VulncheckClient {
+	return &VulncheckClient{
+		http:      &http.Client{Transport: fn},
+		baseURL:   "https://api.vulncheck.com",
+		token:     "test-token",
+		userAgent: "vulncheck-mcp/test",
+	}
+}
+
 func newDocsTestClient(fn roundTripFunc) *VulncheckClient {
 	return &VulncheckClient{
 		http:      &http.Client{Transport: fn},

--- a/internal/client/search_advisory.go
+++ b/internal/client/search_advisory.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-
-	vulncheck "github.com/vulncheck-oss/sdk-go-v2/v2"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
 )
 
 type SearchAdvisoryQuery struct {
@@ -24,76 +27,107 @@ type SearchAdvisoryQuery struct {
 	Cursor        string
 }
 
+// SearchAdvisoryResult holds advisory records as raw JSON rather than generated
+// structs.
+//
+// The MCP server passes these records straight to the model and only ever reads
+// two paths itself (cveMetadata.cveId, and affected[].product/packageName), so
+// typing the payload buys nothing and couples the server to the API's OpenAPI
+// codegen. That coupling is not hypothetical: the generated types cannot decode
+// roughly 80% of /v4/advisory responses, because containers.*.source and
+// containers.*.metrics[].other.content are served as JSON strings wrapping JSON
+// objects. Raw passthrough is immune to that whole class of mismatch, and stays
+// correct once the upstream double-encoding is fixed.
 type SearchAdvisoryResult struct {
-	Data       []vulncheck.AdvisoryMitreCVEListV5Ref `json:"data"`
-	Total      int32                                 `json:"total"`
-	NextCursor string                                `json:"next_cursor,omitempty"`
+	Data       []json.RawMessage `json:"data"`
+	Total      int32             `json:"total"`
+	NextCursor string            `json:"next_cursor,omitempty"`
 }
 
+// advisoryEnvelope is the wire shape of /v4/advisory.
+type advisoryEnvelope struct {
+	Data []json.RawMessage `json:"data"`
+	Meta *struct {
+		Total      int32  `json:"total"`
+		NextCursor string `json:"next_cursor"`
+	} `json:"_meta"`
+}
+
+// SearchAdvisory queries /v4/advisory directly rather than through the generated
+// SDK client, so that a response the SDK's types reject still reaches the caller.
+// This follows the hand-rolled pattern already used by SearchIndex and
+// IdentifyComponent.
 func (c *VulncheckClient) SearchAdvisory(ctx context.Context, q SearchAdvisoryQuery) (*SearchAdvisoryResult, error) {
-	req := c.sdk.AdvisoryAPI.V4QueryAdvisories(c.authContext(ctx))
-	if q.Name != "" {
-		req = req.Name(q.Name)
-	}
-	if q.CveID != "" {
-		req = req.CveId(q.CveID)
-	}
-	if q.Vendor != "" {
-		req = req.Vendor(q.Vendor)
-	}
-	if q.Product != "" {
-		req = req.Product(q.Product)
-	}
-	if q.Platform != "" {
-		req = req.Platform(q.Platform)
-	}
-	if q.Version != "" {
-		req = req.Version(q.Version)
-	}
-	if q.CPE != "" {
-		req = req.Cpe(q.CPE)
-	}
-	if q.PackageName != "" {
-		req = req.PackageName(q.PackageName)
-	}
-	if q.PURL != "" {
-		req = req.Purl(q.PURL)
-	}
-	if q.UpdatedAfter != "" {
-		req = req.UpdatedAfter(q.UpdatedAfter)
-	}
-	if q.UpdatedBefore != "" {
-		req = req.UpdatedBefore(q.UpdatedBefore)
-	}
-	if q.Limit > 0 {
-		req = req.Limit(q.Limit)
-	}
-	if q.StartCursor {
-		req = req.StartCursor("true")
-	}
-	if q.Cursor != "" {
-		req = req.Cursor(q.Cursor)
+	u, err := url.Parse(c.baseURL + "/v4/advisory")
+	if err != nil {
+		return nil, fmt.Errorf("building URL: %w", err)
 	}
 
-	resp, httpResp, err := req.Execute()
-	if httpResp != nil {
-		defer httpResp.Body.Close()
+	p := u.Query()
+	for key, value := range map[string]string{
+		"name":          q.Name,
+		"cve_id":        q.CveID,
+		"vendor":        q.Vendor,
+		"product":       q.Product,
+		"platform":      q.Platform,
+		"version":       q.Version,
+		"cpe":           q.CPE,
+		"package_name":  q.PackageName,
+		"purl":          q.PURL,
+		"updatedAfter":  q.UpdatedAfter,
+		"updatedBefore": q.UpdatedBefore,
+		"cursor":        q.Cursor,
+	} {
+		if value != "" {
+			p.Set(key, value)
+		}
 	}
+	if q.Cursor == "" && q.StartCursor {
+		p.Set("start_cursor", "true")
+	}
+	if q.Limit > 0 {
+		p.Set("limit", strconv.FormatInt(int64(q.Limit), 10))
+	}
+	u.RawQuery = p.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.http.Do(req) //nolint:gosec // G704: baseURL is trusted config
 	if err != nil {
 		return nil, fmt.Errorf("searching advisories: %w", err)
 	}
+	defer resp.Body.Close()
 
-	data := resp.Data
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("searching advisories: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var envelope advisoryEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	data := envelope.Data
 	if data == nil {
-		data = []vulncheck.AdvisoryMitreCVEListV5Ref{}
+		data = []json.RawMessage{}
 	}
 
-	var total int32
-	var nextCursor string
-	if resp.Meta != nil {
-		total = resp.Meta.GetTotal()
-		nextCursor = resp.Meta.GetNextCursor()
+	result := &SearchAdvisoryResult{Data: data}
+	if envelope.Meta != nil {
+		result.Total = envelope.Meta.Total
+		result.NextCursor = envelope.Meta.NextCursor
 	}
 
-	return &SearchAdvisoryResult{Data: data, Total: total, NextCursor: nextCursor}, nil
+	return result, nil
 }

--- a/internal/client/search_advisory_test.go
+++ b/internal/client/search_advisory_test.go
@@ -10,10 +10,14 @@ import (
 
 func TestSearchAdvisory(t *testing.T) {
 	t.Run("returns data with meta", func(t *testing.T) {
-		vc := newSDKTestClient(func(r *http.Request) (*http.Response, error) {
-			assert.Contains(t, r.URL.Path, "/v4")
+		vc := newAPITestClient(func(r *http.Request) (*http.Response, error) {
+			assert.Equal(t, "/v4/advisory", r.URL.Path)
+			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+			assert.Equal(t, "vulncheck-mcp/test", r.Header.Get("User-Agent"))
+			assert.Equal(t, "CVE-2021-44228", r.URL.Query().Get("cve_id"))
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
 			return jsonResp(200, map[string]any{
-				"data":  []map[string]any{{"cve_id": "CVE-2021-44228"}},
+				"data":  []map[string]any{{"cveMetadata": map[string]any{"cveId": "CVE-2021-44228"}}},
 				"_meta": map[string]any{"total": 1, "next_cursor": "cursor-abc"},
 			}), nil
 		})
@@ -24,23 +28,100 @@ func TestSearchAdvisory(t *testing.T) {
 		require.Len(t, result.Data, 1)
 		assert.Equal(t, int32(1), result.Total)
 		assert.Equal(t, "cursor-abc", result.NextCursor)
+		assert.JSONEq(t, `{"cveMetadata":{"cveId":"CVE-2021-44228"}}`, string(result.Data[0]))
+	})
+
+	// The reason records are carried as json.RawMessage: the API serves
+	// containers.cna.source and containers.adp[].metrics[].other.content as JSON
+	// strings wrapping JSON objects, which the generated SDK types reject outright.
+	t.Run("decodes a record the generated SDK types reject", func(t *testing.T) {
+		vc := newAPITestClient(func(_ *http.Request) (*http.Response, error) {
+			return jsonResp(200, map[string]any{
+				"data": []map[string]any{{
+					"cveMetadata": map[string]any{"cveId": "CVE-2025-59532"},
+					"containers": map[string]any{
+						"cna": map[string]any{
+							// double-encoded; the SDK declares this []int32
+							"source": `{"advisory":"GHSA-w5fx-fh39-j5rw","discovery":"UNKNOWN"}`,
+						},
+						"adp": []map[string]any{{
+							"metrics": []map[string]any{{
+								// double-encoded; the SDK declares this map[string]any
+								"other": map[string]any{"type": "ssvc", "content": `{"id":"CVE-2025-59532"}`},
+							}},
+						}},
+					},
+				}},
+				"_meta": map[string]any{"total": 1},
+			}), nil
+		})
+		result, err := vc.SearchAdvisory(t.Context(), SearchAdvisoryQuery{CveID: "CVE-2025-59532"})
+		require.NoError(t, err)
+		require.Len(t, result.Data, 1)
+		assert.Contains(t, string(result.Data[0]), "GHSA-w5fx-fh39-j5rw",
+			"the record reaches the caller verbatim")
+	})
+
+	t.Run("sends every filter as a query parameter", func(t *testing.T) {
+		vc := newAPITestClient(func(r *http.Request) (*http.Response, error) {
+			q := r.URL.Query()
+			assert.Equal(t, "ghsa", q.Get("name"))
+			assert.Equal(t, "Anthropic", q.Get("vendor"), "vendor case must survive verbatim")
+			assert.Equal(t, "Claude Desktop - Windows", q.Get("product"))
+			assert.Equal(t, "@anthropic-ai/claude-code", q.Get("package_name"))
+			assert.Equal(t, "now-30d", q.Get("updatedAfter"))
+			return jsonResp(200, map[string]any{"data": []any{}}), nil
+		})
+		_, err := vc.SearchAdvisory(t.Context(), SearchAdvisoryQuery{
+			Name:         "ghsa",
+			Vendor:       "Anthropic",
+			Product:      "Claude Desktop - Windows",
+			PackageName:  "@anthropic-ai/claude-code",
+			UpdatedAfter: "now-30d",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("start_cursor is dropped once a cursor is supplied", func(t *testing.T) {
+		vc := newAPITestClient(func(r *http.Request) (*http.Response, error) {
+			assert.Equal(t, "page2", r.URL.Query().Get("cursor"))
+			assert.Empty(t, r.URL.Query().Get("start_cursor"))
+			return jsonResp(200, map[string]any{"data": []any{}}), nil
+		})
+		_, err := vc.SearchAdvisory(t.Context(), SearchAdvisoryQuery{
+			Cursor: "page2", StartCursor: true,
+		})
+		require.NoError(t, err)
 	})
 
 	t.Run("nil data normalized to empty slice", func(t *testing.T) {
-		vc := newSDKTestClient(func(_ *http.Request) (*http.Response, error) {
+		vc := newAPITestClient(func(_ *http.Request) (*http.Response, error) {
 			return jsonResp(200, map[string]any{}), nil
 		})
 		result, err := vc.SearchAdvisory(t.Context(), SearchAdvisoryQuery{})
 		require.NoError(t, err)
 		assert.Empty(t, result.Data)
+		assert.NotNil(t, result.Data, "an empty list must not marshal as null")
 	})
 
-	t.Run("SDK error wraps with context", func(t *testing.T) {
-		vc := newSDKTestClient(func(_ *http.Request) (*http.Response, error) {
+	t.Run("HTTP error wraps with context", func(t *testing.T) {
+		vc := newAPITestClient(func(_ *http.Request) (*http.Response, error) {
 			return errResp(500), nil
 		})
 		_, err := vc.SearchAdvisory(t.Context(), SearchAdvisoryQuery{})
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "searching advisories")
+		require.ErrorContains(t, err, "searching advisories")
+		require.ErrorContains(t, err, "500")
+	})
+
+	t.Run("malformed body reports a decode failure", func(t *testing.T) {
+		vc := newAPITestClient(func(_ *http.Request) (*http.Response, error) {
+			resp := jsonResp(200, map[string]any{})
+			resp.Body = http.NoBody
+			return resp, nil
+		})
+		_, err := vc.SearchAdvisory(t.Context(), SearchAdvisoryQuery{})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "decoding response")
 	})
 }

--- a/internal/server/get_cpe_cves.go
+++ b/internal/server/get_cpe_cves.go
@@ -10,14 +10,17 @@ import (
 )
 
 type getCPECVEsArgs struct {
-	CPE            string `json:"cpe"                        jsonschema:"CPE 2.3 string, e.g. 'cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*'"`
+	CPE            string `json:"cpe"                        jsonschema:"CPE 2.3 string, e.g. 'cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*'. Any attribute accepts '*' and '?' wildcards, e.g. 'cpe:2.3:a:apache:log4j*:*:*:*:*:*:*:*'"`
 	VulnerableOnly bool   `json:"vulnerable_only,omitempty"  jsonschema:"When true, return only CVEs where the CPE is confirmed vulnerable (default false)"`
 }
 
 var GetCPECVEsTool = &mcp.Tool{
-	Name:        "get_cpe_cves",
-	Title:       "Get CPE CVEs",
-	Description: "Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable.",
+	Name:  "get_cpe_cves",
+	Title: "Get CPE CVEs",
+	Description: "Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. " +
+		"Any attribute accepts '*' and '?' wildcards, so a trailing wildcard on the product covers every product sharing that prefix in one call — " +
+		"prefer this over search_cpe when exploring a vendor, because search_cpe returns every matching CPE and its response can reach tens of megabytes. " +
+		"Wildcarding both vendor and product is unbounded and should be avoided.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},

--- a/internal/server/search_advisory.go
+++ b/internal/server/search_advisory.go
@@ -4,35 +4,146 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
+	"unicode"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/vulncheck-oss/mcp/internal/client"
 )
 
+// advisoryRecord is the minimal view of an advisory record this handler needs:
+// an identity to de-duplicate on, and the product names to list when a product
+// filter matches nothing. Every other field is passed through to the model
+// untouched, which is why the records are carried as raw JSON.
+type advisoryRecord struct {
+	CveMetadata struct {
+		CveID string `json:"cveId"`
+	} `json:"cveMetadata"`
+	Containers struct {
+		Cna advisoryContainer   `json:"cna"`
+		Adp []advisoryContainer `json:"adp"`
+	} `json:"containers"`
+}
+
+type advisoryContainer struct {
+	Affected []struct {
+		Product     string `json:"product"`
+		PackageName string `json:"packageName"`
+	} `json:"affected"`
+}
+
+// parseAdvisoryRecord reads the two paths above. A record that will not parse
+// yields the zero value rather than an error: it is still returned to the model
+// verbatim, it just cannot be de-duplicated or contribute a product name.
+func parseAdvisoryRecord(raw json.RawMessage) advisoryRecord {
+	var record advisoryRecord
+	_ = json.Unmarshal(raw, &record)
+	return record
+}
+
+const (
+	// maxAdvisoryLimit is the upstream maximum; above it the API returns 400.
+	maxAdvisoryLimit = 100
+
+	// defaultAdvisoryLimit is the upstream maximum, so that by default nothing is
+	// withheld on row count and maxResponseBytes is the only bound.
+	//
+	// Any smaller default is arbitrary and unsafe. The API applies its exact
+	// vendor/product filter to a page only after slicing it, so the rows that
+	// survive — and therefore the order of the union — depend on the page size
+	// requested. A row-count default below the size of the union silently drops
+	// records at a position that shifts with the requested limit and with upstream
+	// paging, which cannot be reasoned about from the outside. Callers that want a
+	// smaller answer ask for one; that request is honoured exactly.
+	defaultAdvisoryLimit = maxAdvisoryLimit
+
+	// maxVendorVariants bounds the case fan-out to one call per spelling.
+	maxVendorVariants = 3
+
+	// maxListedProducts caps the product names reported when the product filter is
+	// dropped, so a large vendor cannot flood the response.
+	maxListedProducts = 25
+
+	// maxResponseBytes bounds the serialized response at roughly 20k tokens.
+	//
+	// `limit` bounds the number of rows, not their size, and advisory records vary by
+	// three orders of magnitude: a ten-row page for a large vendor has been measured
+	// at 6.2 MB (~1.5M tokens), and a single record can exceed 150 KB. Without a byte
+	// bound a widened search can destroy the caller's context, so rows are dropped
+	// whole until the response fits and the count dropped is reported.
+	maxResponseBytes = 80_000
+)
+
+const (
+	widenedNote = "vendor matched case-sensitively upstream, so this response unions several " +
+		"capitalisations; pagination is unavailable for a widened search — re-run with a single " +
+		"exact vendor spelling to paginate"
+
+	productDroppedNote = "no advisory matched that product, so the product filter was dropped and " +
+		"the vendor's advisories are returned instead; product strings are CNA prose and are matched " +
+		"exactly, so pick one from products_found rather than guessing"
+
+	totalMismatchNote = "total counts documents matched before the API's exact vendor/product filter " +
+		"runs, so it is an upper bound on what any spelling can return rather than a count of " +
+		"withheld records"
+
+	trimmedNote = "more records were found than the requested limit; raise limit to see the rest"
+
+	slugNote = "vendor strings are not normalised across sources: GHSA-derived advisories use the " +
+		"publisher's GitHub organisation slug, which is often the plural or hyphenated form of the " +
+		"company name, and other CNAs may use an intercapped brand name. Neither is a capitalisation " +
+		"of the other, so if results look thin, retry with the slug or brand spelling"
+
+	variantFailedNote = "one or more alternative capitalisations could not be retrieved, so this " +
+		"result may be missing advisories filed under them; see vendors_failed"
+
+	truncatedNote = "advisory records vary hugely in size, so rows were dropped to keep this " +
+		"response within a usable context budget; dropped rows are omitted whole, never abridged — " +
+		"narrow the query or fetch a specific cve_id for the rest"
+)
+
 type searchAdvisoryArgs struct {
 	Name          string `json:"name,omitempty"           jsonschema:"Advisory feed name, e.g. 'ghsa' — use v4_list_advisories to discover valid names"`
 	CveID         string `json:"cve_id,omitempty"         jsonschema:"Filter by CVE ID, e.g. 'CVE-2024-1234'"`
-	Vendor        string `json:"vendor,omitempty"         jsonschema:"Filter by vendor name"`
-	Product       string `json:"product,omitempty"        jsonschema:"Filter by product name"`
+	Vendor        string `json:"vendor,omitempty"         jsonschema:"Filter by vendor as the CNA published it. Matched exactly and case-sensitively upstream; alternative capitalisations are retried automatically"`
+	Product       string `json:"product,omitempty"        jsonschema:"Filter by product as the CNA published it, which is often prose rather than a slug. Matched exactly, with no prefix or substring matching; if nothing matches, the filter is dropped and the vendor's product names are listed instead"`
 	Platform      string `json:"platform,omitempty"       jsonschema:"Filter by OS or platform"`
 	Version       string `json:"version,omitempty"        jsonschema:"Filter by product version (semver-aware)"`
 	CPE           string `json:"cpe,omitempty"            jsonschema:"Filter by CPE 2.3 string"`
-	PackageName   string `json:"package_name,omitempty"   jsonschema:"Filter by package name"`
+	PackageName   string `json:"package_name,omitempty"   jsonschema:"Filter by registry package name, including any scope — the most reliable filter for package-ecosystem software"`
 	PURL          string `json:"purl,omitempty"           jsonschema:"Filter by Package URL (PURL)"`
 	UpdatedAfter  string `json:"updated_after,omitempty"  jsonschema:"Return advisories updated after this date (RFC3339 or date-math, e.g. 'now-30d')"`
 	UpdatedBefore string `json:"updated_before,omitempty" jsonschema:"Return advisories updated before this date (RFC3339 or date-math)"`
-	Limit         int32  `json:"limit,omitempty"          jsonschema:"Results per page, max 100 (default: 1)"`
+	Limit         int32  `json:"limit,omitempty"          jsonschema:"Maximum records to return, max 100 (default: 100, bounded instead by response size). Lower it only to shrink the response: because the API filters each page after slicing it, a smaller limit withholds records rather than selecting the most relevant ones"`
 	StartCursor   bool   `json:"start_cursor,omitempty"   jsonschema:"Set true on the first call to enable cursor-based pagination"`
 	Cursor        string `json:"cursor,omitempty"         jsonschema:"Cursor token from a previous next_cursor to fetch the next page"`
 }
 
 var SearchAdvisoryTool = &mcp.Tool{
-	Name:        "v4_search_advisory",
-	Title:       "Search Advisory",
-	Description: "Search VulnCheck v4 advisory feeds. Filter by advisory name, CVE ID, vendor, product, version, CPE, PURL, and more. Supports cursor-based pagination.",
+	Name:  "v4_search_advisory",
+	Title: "Search Advisory",
+	Description: "Search VulnCheck v4 advisory feeds. Filter by advisory name, CVE ID, vendor, product, version, CPE, PURL, and more. " +
+		"This is the tool that finds advisories carrying no CPE data, such as GHSA records for npm, PyPI and Go software — prefer it over the CPE tools for package-ecosystem products. " +
+		"Vendor and product are matched exactly and case-sensitively against the CNA-published strings; alternative capitalisations are retried automatically and an unmatchable product filter is dropped, with both explained in notes.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
+}
+
+// searchAdvisoryResponse wraps the client result so the handler can explain, in
+// band, when it widened the query and why the API's own total may exceed the rows
+// returned. Every added field is omitempty, so an un-widened response keeps the
+// wire shape callers already depend on.
+type searchAdvisoryResponse struct {
+	*client.SearchAdvisoryResult
+	Returned      int      `json:"returned,omitempty"`
+	Dropped       int      `json:"dropped_for_size,omitempty"`
+	DroppedCVEs   []string `json:"dropped_cves,omitempty"`
+	VendorsTried  []string `json:"vendors_tried,omitempty"`
+	VendorsFailed []string `json:"vendors_failed,omitempty"`
+	ProductsFound []string `json:"products_found,omitempty"`
+	Notes         []string `json:"notes,omitempty"`
 }
 
 func registerSearchAdvisory(srv *mcp.Server, vc client.Client) {
@@ -41,31 +152,38 @@ func registerSearchAdvisory(srv *mcp.Server, vc client.Client) {
 
 func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdvisoryArgs, any] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, args searchAdvisoryArgs) (*mcp.CallToolResult, any, error) {
-		limit := args.Limit
-		if limit <= 0 {
-			limit = 1
-		}
-		result, err := vc.SearchAdvisory(ctx, client.SearchAdvisoryQuery{
-			Name:          args.Name,
-			CveID:         args.CveID,
-			Vendor:        args.Vendor,
-			Product:       args.Product,
-			Platform:      args.Platform,
-			Version:       args.Version,
-			CPE:           args.CPE,
-			PackageName:   args.PackageName,
-			PURL:          args.PURL,
-			UpdatedAfter:  args.UpdatedAfter,
-			UpdatedBefore: args.UpdatedBefore,
-			Limit:         limit,
-			StartCursor:   args.StartCursor,
-			Cursor:        args.Cursor,
-		})
+		query := advisoryQuery(args)
+
+		result, err := vc.SearchAdvisory(ctx, query)
 		if err != nil {
 			return nil, nil, fmt.Errorf("searching advisories: %w", err)
 		}
 
-		out, err := json.Marshal(result)
+		response := searchAdvisoryResponse{SearchAdvisoryResult: result}
+		if canWiden(query) && underDelivered(result) {
+			response = widenAdvisorySearch(ctx, vc, query, result)
+			// Widening reads larger upstream pages than the caller asked for,
+			// because the exact filter downstream of them only sees one page. That
+			// is a transport detail: `limit` still means "at most this many rows",
+			// so the union is trimmed back to it.
+			if int(query.Limit) < len(response.Data) {
+				response.Data = response.Data[:query.Limit]
+				response.Notes = append(response.Notes, trimmedNote)
+			}
+		}
+
+		if dropped, ids := capResponseBytes(&response); dropped > 0 {
+			response.Dropped = dropped
+			response.DroppedCVEs = ids
+			response.Notes = append(response.Notes, truncatedNote)
+		}
+
+		response.Returned = len(response.Data)
+		if int(response.Total) > len(response.Data) {
+			response.Notes = append(response.Notes, totalMismatchNote, slugNote)
+		}
+
+		out, err := json.Marshal(response)
 		if err != nil {
 			return nil, nil, fmt.Errorf("serializing results: %w", err)
 		}
@@ -74,4 +192,356 @@ func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdviso
 			Content: []mcp.Content{&mcp.TextContent{Text: string(out)}},
 		}, nil, nil
 	}
+}
+
+// capResponseBytes drops whole rows until the response fits inside
+// maxResponseBytes, returning how many were dropped and naming them.
+//
+// Rows are never abridged: a partial advisory record would be indistinguishable
+// from a complete one and could be read as authoritative. An oversized row is
+// skipped rather than ending the walk, so one enormous record cannot hide the
+// smaller ones behind it — a single advisory has been measured at ~700 KB alone,
+// which is why keeping "at least one row" is not a safe floor here. Dropped rows
+// are named so the caller can fetch them individually by cve_id.
+func capResponseBytes(response *searchAdvisoryResponse) (int, []string) {
+	if response.SearchAdvisoryResult == nil || len(response.Data) == 0 {
+		return 0, nil
+	}
+
+	encoded, err := json.Marshal(response)
+	if err != nil || len(encoded) <= maxResponseBytes {
+		return 0, nil
+	}
+
+	// Budget only the rows; the surrounding envelope and notes are small and fixed.
+	budget := maxResponseBytes - (len(encoded) - rowsSize(response.Data))
+	kept := make([]json.RawMessage, 0, len(response.Data))
+	var dropped []string
+	used := 0
+
+	for _, raw := range response.Data {
+		size := len(raw) + 1 // the comma that joins it to the previous row
+		if used+size > budget {
+			record := parseAdvisoryRecord(raw)
+			if id := record.CveMetadata.CveID; id != "" && len(dropped) < maxListedProducts {
+				dropped = append(dropped, id)
+			}
+			continue
+		}
+		used += size
+		kept = append(kept, raw)
+	}
+
+	count := len(response.Data) - len(kept)
+	response.Data = kept
+	return count, dropped
+}
+
+// rowsSize reports the serialized size of the row list. Raw records need no
+// re-encoding, so this is just their lengths plus the separators.
+func rowsSize(data []json.RawMessage) int {
+	size := 2 // the enclosing brackets
+	for _, raw := range data {
+		size += len(raw) + 1
+	}
+	return size
+}
+
+func advisoryQuery(args searchAdvisoryArgs) client.SearchAdvisoryQuery {
+	limit := args.Limit
+	if limit <= 0 {
+		limit = defaultAdvisoryLimit
+	}
+	if limit > maxAdvisoryLimit {
+		limit = maxAdvisoryLimit
+	}
+
+	return client.SearchAdvisoryQuery{
+		Name:          args.Name,
+		CveID:         args.CveID,
+		Vendor:        args.Vendor,
+		Product:       args.Product,
+		Platform:      args.Platform,
+		Version:       args.Version,
+		CPE:           args.CPE,
+		PackageName:   args.PackageName,
+		PURL:          args.PURL,
+		UpdatedAfter:  args.UpdatedAfter,
+		UpdatedBefore: args.UpdatedBefore,
+		Limit:         limit,
+		StartCursor:   args.StartCursor,
+		Cursor:        args.Cursor,
+	}
+}
+
+// coveringLimit returns a page size large enough to hold every document the API
+// says matches, so the exact filter downstream of it sees the whole set rather than
+// an unstable sample. It never shrinks the caller's limit and never exceeds the
+// upstream maximum.
+func coveringLimit(limit, total int32) int32 {
+	if total > limit {
+		limit = total
+	}
+	if limit > maxAdvisoryLimit {
+		limit = maxAdvisoryLimit
+	}
+	return limit
+}
+
+// canWiden reports whether retrying is meaningful. A cursor addresses one
+// specific query's page and cannot be replayed against a different spelling, so
+// paginated calls are always passed through untouched.
+func canWiden(q client.SearchAdvisoryQuery) bool {
+	return q.Vendor != "" && q.Cursor == ""
+}
+
+// underDelivered reports whether the API's exact post-filter appears to have
+// discarded matches: either nothing survived, or it reports more matching
+// documents than it handed back.
+func underDelivered(r *client.SearchAdvisoryResult) bool {
+	return len(r.Data) == 0 || int(r.Total) > len(r.Data)
+}
+
+// widenAdvisorySearch retries the query under alternative vendor capitalisations
+// and, if that still finds nothing, once more without the product filter.
+//
+// Both are workarounds for the upstream filter comparing vendor and product with
+// a case-sensitive `==` after the page has been sliced. They should be deleted
+// once the API matches case-insensitively — at which point a single call returns
+// the full set and this function has no job left.
+func widenAdvisorySearch(
+	ctx context.Context,
+	vc client.Client,
+	query client.SearchAdvisoryQuery,
+	first *client.SearchAdvisoryResult,
+) searchAdvisoryResponse {
+	// The upstream filter runs on one page at a time, and that page's ordering is
+	// not stable between calls, so while total exceeds the page size which rows
+	// survive varies run to run. Widening the page to cover the whole match set
+	// makes the answer both complete and reproducible; beyond the upstream maximum
+	// it is capped, and the byte budget bounds the response either way.
+	narrow := query.Limit
+	query.Limit = coveringLimit(query.Limit, first.Total)
+
+	merged := newAdvisoryMerge(first)
+	tried := []string{query.Vendor}
+	var failed []string
+
+	// The caller's own spelling was queried at the narrower limit, so repeat it at
+	// the covering one rather than keeping a partial page. Skipped when the limit
+	// did not actually grow, since that would just repeat the call already made.
+	if query.Limit > narrow {
+		if requery, err := vc.SearchAdvisory(ctx, query); err == nil {
+			merged.add(requery)
+		}
+	}
+
+	for _, vendor := range vendorCaseVariants(query.Vendor) {
+		if vendor == query.Vendor {
+			continue
+		}
+		tried = append(tried, vendor)
+
+		next := query
+		next.Vendor = vendor
+		// A failing variant must not discard the rows already collected; the
+		// caller's own spelling already succeeded or we would not be here. It is
+		// reported rather than swallowed, so a systemic upstream failure cannot
+		// masquerade as "this spelling has no advisories".
+		res, err := vc.SearchAdvisory(ctx, next)
+		if err != nil {
+			failed = append(failed, vendor)
+			continue
+		}
+		merged.add(res)
+	}
+
+	notes := []string{widenedNote}
+	if len(failed) > 0 {
+		notes = append(notes, variantFailedNote)
+	}
+
+	response := searchAdvisoryResponse{
+		SearchAdvisoryResult: merged.result(),
+		VendorsTried:         tried,
+		VendorsFailed:        failed,
+		Notes:                notes,
+	}
+	if len(response.Data) > 0 || query.Product == "" {
+		return response
+	}
+
+	// Product strings are CNA prose, often with spaces and punctuation, matched
+	// exactly. A plausible guess therefore matches nothing, and returning the
+	// vendor's advisories plus the real product names is more use than an empty
+	// result.
+	return dropProductFilter(ctx, vc, query, tried)
+}
+
+func dropProductFilter(
+	ctx context.Context,
+	vc client.Client,
+	query client.SearchAdvisoryQuery,
+	tried []string,
+) searchAdvisoryResponse {
+	query.Product = ""
+	// Dropping the filter widens the match set by an unknown amount, and the same
+	// unstable-page problem applies, so request the largest page the API allows.
+	// The byte budget bounds the response.
+	query.Limit = maxAdvisoryLimit
+
+	var merged *advisoryMerge
+	var failed []string
+	for _, vendor := range tried {
+		next := query
+		next.Vendor = vendor
+		res, err := vc.SearchAdvisory(ctx, next)
+		if err != nil {
+			failed = append(failed, vendor)
+			continue
+		}
+		if merged == nil {
+			merged = newAdvisoryMerge(res)
+			continue
+		}
+		merged.add(res)
+	}
+	if merged == nil {
+		merged = newAdvisoryMerge(&client.SearchAdvisoryResult{Data: []json.RawMessage{}})
+	}
+
+	result := merged.result()
+
+	notes := []string{productDroppedNote, widenedNote}
+	if len(failed) > 0 {
+		notes = append(notes, variantFailedNote)
+	}
+
+	return searchAdvisoryResponse{
+		SearchAdvisoryResult: result,
+		VendorsTried:         tried,
+		VendorsFailed:        failed,
+		ProductsFound:        productNames(result.Data),
+		Notes:                notes,
+	}
+}
+
+// vendorCaseVariants returns the spellings to try, in a fixed order so the merged
+// result is deterministic: as supplied, lowercase, then capitalised.
+//
+// This cannot reach every spelling. Publisher GitHub organisation slugs and
+// intercapped brand names are not capitalisations of what a caller would type, so
+// slugNote points the caller at those instead.
+func vendorCaseVariants(vendor string) []string {
+	variants := make([]string, 0, maxVendorVariants)
+	for _, candidate := range []string{vendor, strings.ToLower(vendor), capitalise(vendor)} {
+		if candidate == "" || slices.Contains(variants, candidate) {
+			continue
+		}
+		variants = append(variants, candidate)
+	}
+	return variants
+}
+
+func capitalise(s string) string {
+	runes := []rune(s)
+	if len(runes) == 0 {
+		return s
+	}
+	return string(unicode.ToUpper(runes[0])) + strings.ToLower(string(runes[1:]))
+}
+
+// advisoryMerge unions results from several vendor spellings, de-duplicating by
+// CVE ID.
+//
+// Each spelling's rows are kept as a separate batch and interleaved on output, so
+// that trimming the union to the caller's limit takes a fair share from every
+// spelling. Concatenating instead would put the later spellings last and let a
+// small limit discard precisely the rows the fan-out went looking for.
+type advisoryMerge struct {
+	batches [][]json.RawMessage
+	seen    map[string]struct{}
+	total   int32
+}
+
+func newAdvisoryMerge(first *client.SearchAdvisoryResult) *advisoryMerge {
+	m := &advisoryMerge{seen: map[string]struct{}{}}
+	m.add(first)
+	return m
+}
+
+func (m *advisoryMerge) add(r *client.SearchAdvisoryResult) {
+	// Every spelling reports the same pre-filter count for the same coarse match,
+	// so summing would multiply it. Keep the largest seen.
+	if r.Total > m.total {
+		m.total = r.Total
+	}
+	batch := make([]json.RawMessage, 0, len(r.Data))
+	for _, raw := range r.Data {
+		// Records without a CVE ID cannot be de-duplicated; keep them rather than
+		// collapsing distinct advisories into one.
+		record := parseAdvisoryRecord(raw)
+		if id := record.CveMetadata.CveID; id != "" {
+			if _, ok := m.seen[id]; ok {
+				continue
+			}
+			m.seen[id] = struct{}{}
+		}
+		batch = append(batch, raw)
+	}
+	if len(batch) > 0 {
+		m.batches = append(m.batches, batch)
+	}
+}
+
+// result reports the union, interleaved across spellings. NextCursor is
+// deliberately dropped: it belongs to one spelling's query and cannot paginate a
+// union.
+func (m *advisoryMerge) result() *client.SearchAdvisoryResult {
+	var size int
+	for _, batch := range m.batches {
+		size += len(batch)
+	}
+
+	data := make([]json.RawMessage, 0, size)
+	for i := 0; len(data) < size; i++ {
+		for _, batch := range m.batches {
+			if i < len(batch) {
+				data = append(data, batch[i])
+			}
+		}
+	}
+
+	return &client.SearchAdvisoryResult{Data: data, Total: m.total}
+}
+
+// productNames lists the distinct product and package names present, so a caller
+// whose product guess missed can pick a real one.
+func productNames(data []json.RawMessage) []string {
+	seen := map[string]struct{}{}
+	names := make([]string, 0, maxListedProducts)
+
+	for _, raw := range data {
+		record := parseAdvisoryRecord(raw)
+		affected := record.Containers.Cna.Affected
+		for _, adp := range record.Containers.Adp {
+			affected = append(affected, adp.Affected...)
+		}
+		for _, a := range affected {
+			for _, name := range []string{a.Product, a.PackageName} {
+				if name == "" || len(names) == maxListedProducts {
+					continue
+				}
+				if _, ok := seen[name]; ok {
+					continue
+				}
+				seen[name] = struct{}{}
+				names = append(names, name)
+			}
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
 }

--- a/internal/server/search_advisory_test.go
+++ b/internal/server/search_advisory_test.go
@@ -4,14 +4,105 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vulncheck-oss/mcp/internal/client"
-	v2 "github.com/vulncheck-oss/sdk-go-v2/v2"
 )
+
+// advisoryRef builds a result row identified by CVE ID, optionally naming the
+// products it affects. Rows are raw JSON, matching what the API returns and what
+// the handler passes through.
+func advisoryRef(cve string, products ...string) json.RawMessage {
+	record := map[string]any{}
+	if cve != "" {
+		record["cveMetadata"] = map[string]any{"cveId": cve}
+	}
+	if len(products) > 0 {
+		affected := make([]map[string]any, 0, len(products))
+		for _, p := range products {
+			affected = append(affected, map[string]any{"product": p})
+		}
+		record["containers"] = map[string]any{"cna": map[string]any{"affected": affected}}
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+// advisoryRefWithSource builds a row carrying the double-encoded `source` value
+// that the generated SDK types cannot decode: a JSON string wrapping a JSON object.
+func advisoryRefWithSource(cve string) json.RawMessage {
+	raw, err := json.Marshal(map[string]any{
+		"cveMetadata": map[string]any{"cveId": cve},
+		"containers": map[string]any{
+			"cna": map[string]any{
+				"source": `{"advisory":"GHSA-w5fx-fh39-j5rw","discovery":"UNKNOWN"}`,
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func advisoryResult(total int32, refs ...json.RawMessage) *client.SearchAdvisoryResult {
+	if refs == nil {
+		refs = []json.RawMessage{}
+	}
+	return &client.SearchAdvisoryResult{Data: refs, Total: total}
+}
+
+// cveIDs reads the CVE IDs out of a response's rows.
+func cveIDs(t *testing.T, data []json.RawMessage) []string {
+	t.Helper()
+	ids := make([]string, 0, len(data))
+	for _, raw := range data {
+		var record struct {
+			CveMetadata struct {
+				CveID string `json:"cveId"`
+			} `json:"cveMetadata"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &record))
+		ids = append(ids, record.CveMetadata.CveID)
+	}
+	return ids
+}
+
+// runAdvisoryHandler invokes the handler against a mock that answers from respond
+// and records every query it was asked, so a test can assert the fan-out.
+func runAdvisoryHandler(
+	t *testing.T,
+	args searchAdvisoryArgs,
+	respond func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error),
+) (searchAdvisoryResponse, []client.SearchAdvisoryQuery, error) {
+	t.Helper()
+
+	var queries []client.SearchAdvisoryQuery
+	mock := &mockClient{
+		searchAdvisoryFn: func(_ context.Context, q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+			queries = append(queries, q)
+			return respond(q)
+		},
+	}
+
+	result, _, err := MakeSearchAdvisoryHandler(mock)(context.Background(), nil, args)
+	if err != nil {
+		return searchAdvisoryResponse{}, queries, err
+	}
+
+	var got searchAdvisoryResponse
+	text := result.Content[0].(*mcp.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(text), &got))
+	return got, queries, nil
+}
 
 func TestMakeSearchAdvisoryHandler(t *testing.T) {
 	tests := []struct {
@@ -25,21 +116,24 @@ func TestMakeSearchAdvisoryHandler(t *testing.T) {
 		wantLen    int
 	}{
 		{
-			name: "returns advisory results",
-			args: searchAdvisoryArgs{Name: "vulncheck", CveID: "CVE-2024-1234", Limit: 5},
-			clientResp: &client.SearchAdvisoryResult{
-				Data:  []v2.AdvisoryMitreCVEListV5Ref{{}},
-				Total: 1,
-			},
-			wantLimit: 5,
-			wantTotal: 1,
-			wantLen:   1,
+			name:       "returns advisory results",
+			args:       searchAdvisoryArgs{Name: "vulncheck", CveID: "CVE-2024-1234", Limit: 5},
+			clientResp: advisoryResult(1, advisoryRef("CVE-2024-1234")),
+			wantLimit:  5,
+			wantTotal:  1,
+			wantLen:    1,
 		},
 		{
-			name:       "zero limit defaults to 1",
+			name:       "zero limit defaults to ten",
 			args:       searchAdvisoryArgs{Name: "vulncheck"},
-			clientResp: &client.SearchAdvisoryResult{Data: []v2.AdvisoryMitreCVEListV5Ref{}, Total: 0},
-			wantLimit:  1,
+			clientResp: advisoryResult(0),
+			wantLimit:  defaultAdvisoryLimit,
+		},
+		{
+			name:       "limit is clamped to the upstream maximum",
+			args:       searchAdvisoryArgs{Name: "vulncheck", Limit: 500},
+			clientResp: advisoryResult(0),
+			wantLimit:  maxAdvisoryLimit,
 		},
 		{
 			name:      "client error propagates",
@@ -51,33 +145,454 @@ func TestMakeSearchAdvisoryHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var gotQuery client.SearchAdvisoryQuery
-
-			mock := &mockClient{
-				searchAdvisoryFn: func(_ context.Context, q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
-					gotQuery = q
+			got, queries, err := runAdvisoryHandler(t, tt.args,
+				func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
 					return tt.clientResp, tt.clientErr
-				},
-			}
-
-			handler := MakeSearchAdvisoryHandler(mock)
-			result, _, err := handler(context.Background(), nil, tt.args)
+				})
 
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
+			require.NotEmpty(t, queries)
 
-			assert.Equal(t, tt.args.Name, gotQuery.Name)
-			assert.Equal(t, tt.args.CveID, gotQuery.CveID)
-			assert.Equal(t, tt.wantLimit, gotQuery.Limit)
-
-			text := result.Content[0].(*mcp.TextContent).Text
-			var got client.SearchAdvisoryResult
-			require.NoError(t, json.Unmarshal([]byte(text), &got))
+			assert.Equal(t, tt.args.Name, queries[0].Name)
+			assert.Equal(t, tt.args.CveID, queries[0].CveID)
+			assert.Equal(t, tt.wantLimit, queries[0].Limit)
 			assert.Equal(t, tt.wantTotal, got.Total)
 			assert.Len(t, got.Data, tt.wantLen)
 		})
 	}
+}
+
+// TestSearchAdvisoryNoWidening covers the paths that must keep issuing exactly one
+// upstream call and returning the wire shape callers already depend on.
+func TestSearchAdvisoryNoWidening(t *testing.T) {
+	t.Run("a complete result is not widened", func(t *testing.T) {
+		got, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropics"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(2, advisoryRef("CVE-1"), advisoryRef("CVE-2")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Len(t, queries, 1, "total equals the rows returned, so nothing was discarded")
+		assert.Empty(t, got.VendorsTried)
+		assert.Empty(t, got.Notes)
+	})
+
+	t.Run("a cursor is passed through without widening", func(t *testing.T) {
+		_, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Cursor: "abc"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(25), nil
+			})
+
+		require.NoError(t, err)
+		assert.Len(t, queries, 1, "a cursor addresses one query's page and cannot be replayed")
+	})
+
+	t.Run("no vendor means nothing to vary", func(t *testing.T) {
+		_, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{CveID: "CVE-2024-1234"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(9), nil
+			})
+
+		require.NoError(t, err)
+		assert.Len(t, queries, 1)
+	})
+}
+
+func TestSearchAdvisoryVendorFanOut(t *testing.T) {
+	t.Run("recovers rows filed under another capitalisation", func(t *testing.T) {
+		got, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic"},
+			func(q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				if q.Vendor == "Anthropic" {
+					return advisoryResult(25, advisoryRef("CVE-2026-22561")), nil
+				}
+				return advisoryResult(25, advisoryRef("CVE-2026-33068")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"anthropic", "Anthropic"}, got.VendorsTried)
+		assert.Equal(t, []string{"CVE-2026-33068", "CVE-2026-22561"}, cveIDs(t, got.Data),
+			"union preserves first-seen order")
+
+		assert.Equal(t, "anthropic", queries[0].Vendor)
+		assert.Equal(t, "Anthropic", queries[len(queries)-1].Vendor)
+		assert.Contains(t, got.Notes, widenedNote)
+	})
+
+	// The upstream filter runs on one page and that page's ordering is unstable, so
+	// a limit below the reported total yields a different sample per call. The
+	// handler must widen the page to cover the whole match set.
+	t.Run("the page is widened to cover the reported total", func(t *testing.T) {
+		_, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Limit: 10},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(25, advisoryRef("CVE-1")), nil
+			})
+
+		require.NoError(t, err)
+		require.Greater(t, len(queries), 1)
+		assert.Equal(t, int32(10), queries[0].Limit, "the first call honours the caller")
+		for _, q := range queries[1:] {
+			assert.Equal(t, int32(25), q.Limit, "widened calls cover the reported total")
+		}
+	})
+
+	t.Run("the covering limit is capped at the upstream maximum", func(t *testing.T) {
+		_, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "linux"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(10536, advisoryRef("CVE-1")), nil
+			})
+
+		require.NoError(t, err)
+		for _, q := range queries[1:] {
+			assert.Equal(t, int32(maxAdvisoryLimit), q.Limit)
+		}
+	})
+
+	t.Run("no re-query when the limit already covers the total", func(t *testing.T) {
+		_, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Limit: 100},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(25), nil
+			})
+
+		require.NoError(t, err)
+		assert.Len(t, queries, 2, "one call per spelling, with no redundant repeat")
+	})
+
+	t.Run("an all-caps vendor tries three spellings", func(t *testing.T) {
+		got, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "ANTHROPIC", Limit: 100},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(25), nil
+			})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"ANTHROPIC", "anthropic", "Anthropic"}, got.VendorsTried)
+		assert.Len(t, queries, maxVendorVariants, "one call per spelling")
+	})
+
+	t.Run("the same CVE from two spellings is returned once", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(25, advisoryRef("CVE-DUPE")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Len(t, got.Data, 1)
+	})
+
+	t.Run("rows without a CVE ID are kept rather than collapsed", func(t *testing.T) {
+		got, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(25, advisoryRef(""), advisoryRef("")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Len(t, got.Data, 2*len(queries),
+			"unidentifiable rows cannot be de-duplicated, so every call's rows are kept")
+	})
+
+	t.Run("a failing variant does not lose the rows already found", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic"},
+			func(q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				if q.Vendor == "Anthropic" {
+					return nil, errors.New("upstream 500")
+				}
+				return advisoryResult(25, advisoryRef("CVE-KEPT")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Len(t, got.Data, 1)
+	})
+
+	t.Run("a failing variant is reported, not swallowed", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic"},
+			func(q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				if q.Vendor == "Anthropic" {
+					return nil, errors.New("json: cannot unmarshal string into Go struct field")
+				}
+				return advisoryResult(25, advisoryRef("CVE-KEPT")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Anthropic"}, got.VendorsFailed,
+			"an upstream failure must not look like a spelling with no advisories")
+		assert.Contains(t, got.Notes, variantFailedNote)
+	})
+
+	t.Run("a widened response drops next_cursor", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return &client.SearchAdvisoryResult{
+					Data:       []json.RawMessage{advisoryRef("CVE-1")},
+					Total:      25,
+					NextCursor: "cursor-abc",
+				}, nil
+			})
+
+		require.NoError(t, err)
+		assert.Empty(t, got.NextCursor, "a cursor cannot paginate a union of spellings")
+	})
+
+	t.Run("total exceeding the rows returned is explained", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(25, advisoryRef("CVE-1")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Contains(t, got.Notes, totalMismatchNote)
+		assert.Contains(t, got.Notes, slugNote)
+	})
+}
+
+func TestSearchAdvisoryProductFallback(t *testing.T) {
+	t.Run("an unmatchable product is dropped and real products listed", func(t *testing.T) {
+		got, queries, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Product: "claude"},
+			func(q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				if q.Product != "" {
+					return advisoryResult(0), nil
+				}
+				return advisoryResult(25, advisoryRef("CVE-2026-22561", "Claude Desktop - Windows")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Contains(t, got.Notes, productDroppedNote)
+		assert.Equal(t, []string{"Claude Desktop - Windows"}, got.ProductsFound)
+		require.NotEmpty(t, got.Data)
+
+		for _, q := range queries[len(queries)-2:] {
+			assert.Empty(t, q.Product, "the retry drops the product filter")
+			assert.Equal(t, int32(maxAdvisoryLimit), q.Limit,
+				"the widened match set needs the largest page the API allows")
+		}
+	})
+
+	t.Run("a product that does match is left alone", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Product: "Claude Desktop - Windows"},
+			func(q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				require.NotEmpty(t, q.Product)
+				return advisoryResult(25, advisoryRef("CVE-2026-22561")), nil
+			})
+
+		require.NoError(t, err)
+		assert.NotContains(t, got.Notes, productDroppedNote)
+	})
+}
+
+// TestSearchAdvisoryResponseSize covers the byte bound. `limit` caps the number of
+// rows but not their size — a single vendor=linux advisory is ~700 KB, and before
+// this bound the same query returned 6.2 MB.
+func TestSearchAdvisoryResponseSize(t *testing.T) {
+	// bulkyRef builds a row whose serialized size is dominated by one long field.
+	bulkyRef := func(cve string, padding int) json.RawMessage {
+		raw, err := json.Marshal(map[string]any{
+			"cveMetadata": map[string]any{"cveId": cve},
+			"containers": map[string]any{
+				"cna": map[string]any{"title": strings.Repeat("x", padding)},
+			},
+		})
+		require.NoError(t, err)
+		return raw
+	}
+
+	t.Run("oversized rows are dropped and named", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "linux"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(10,
+					bulkyRef("CVE-HUGE-1", maxResponseBytes),
+					bulkyRef("CVE-HUGE-2", maxResponseBytes),
+				), nil
+			})
+
+		require.NoError(t, err)
+		assert.Empty(t, got.Data, "no row fits, so none is returned")
+		assert.Positive(t, got.Dropped)
+		assert.Contains(t, got.DroppedCVEs, "CVE-HUGE-1",
+			"dropped rows must be named so they can be fetched by cve_id")
+		assert.Contains(t, got.Notes, truncatedNote)
+	})
+
+	t.Run("a small row behind an oversized one is still returned", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "linux"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(10,
+					bulkyRef("CVE-HUGE", maxResponseBytes),
+					advisoryRef("CVE-SMALL"),
+				), nil
+			})
+
+		require.NoError(t, err)
+		require.Len(t, got.Data, 1, "an oversized row is skipped, not a stop signal")
+		assert.Equal(t, []string{"CVE-SMALL"}, cveIDs(t, got.Data))
+	})
+
+	t.Run("responses stay within the byte bound", func(t *testing.T) {
+		var refs []json.RawMessage
+		for i := range 40 {
+			refs = append(refs, bulkyRef(fmt.Sprintf("CVE-%d", i), 20_000))
+		}
+
+		mock := &mockClient{
+			searchAdvisoryFn: func(_ context.Context, _ client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(500, refs...), nil
+			},
+		}
+		result, _, err := MakeSearchAdvisoryHandler(mock)(
+			context.Background(), nil, searchAdvisoryArgs{Vendor: "linux"})
+		require.NoError(t, err)
+
+		text := result.Content[0].(*mcp.TextContent).Text
+		assert.LessOrEqual(t, len(text), maxResponseBytes+len(truncatedNote)+2048,
+			"the serialized response must stay near the budget")
+	})
+
+	t.Run("a small result is untouched", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropics"},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return advisoryResult(1, advisoryRef("CVE-1")), nil
+			})
+
+		require.NoError(t, err)
+		assert.Zero(t, got.Dropped)
+		assert.Empty(t, got.DroppedCVEs)
+		assert.NotContains(t, got.Notes, truncatedNote)
+	})
+}
+
+// TestSearchAdvisoryLimitContract covers what `limit` means to a caller: at most
+// that many rows come back. Widening reads larger upstream pages than requested,
+// because the API's exact filter only ever sees one page, but that is a transport
+// detail and must not leak into the row count.
+func TestSearchAdvisoryLimitContract(t *testing.T) {
+	// respond gives each spelling four distinct rows, so a union of 8 exists.
+	respond := func(q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+		prefix := "lower"
+		if q.Vendor == "Anthropic" {
+			prefix = "upper"
+		}
+		refs := make([]json.RawMessage, 0, 4)
+		for i := range 4 {
+			refs = append(refs, advisoryRef(fmt.Sprintf("CVE-%s-%d", prefix, i)))
+		}
+		return advisoryResult(25, refs...), nil
+	}
+
+	for _, limit := range []int32{1, 2, 5, 8} {
+		t.Run(fmt.Sprintf("limit %d is honoured", limit), func(t *testing.T) {
+			got, _, err := runAdvisoryHandler(t,
+				searchAdvisoryArgs{Vendor: "anthropic", Limit: limit}, respond)
+
+			require.NoError(t, err)
+			assert.LessOrEqual(t, len(got.Data), int(limit),
+				"a caller asking for N rows must not receive more")
+			assert.Equal(t, len(got.Data), got.Returned)
+		})
+	}
+
+	t.Run("trimming is disclosed, not silent", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Limit: 2}, respond)
+
+		require.NoError(t, err)
+		assert.Contains(t, got.Notes, trimmedNote,
+			"records were found and withheld, so total exceeding returned is real loss here")
+	})
+
+	t.Run("no trim note when everything found is returned", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Limit: 100}, respond)
+
+		require.NoError(t, err)
+		assert.NotContains(t, got.Notes, trimmedNote)
+	})
+
+	t.Run("a small limit still samples every spelling", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Vendor: "anthropic", Limit: 2}, respond)
+
+		require.NoError(t, err)
+		ids := cveIDs(t, got.Data)
+		require.Len(t, ids, 2)
+
+		var sawLower, sawUpper bool
+		for _, id := range ids {
+			sawLower = sawLower || strings.Contains(id, "lower")
+			sawUpper = sawUpper || strings.Contains(id, "upper")
+		}
+		assert.True(t, sawLower && sawUpper,
+			"rows are interleaved, so trimming cannot discard a whole spelling: got %v", ids)
+	})
+}
+
+// TestSearchAdvisoryRawPassthrough guards the reason records are carried as raw
+// JSON: the API double-encodes containers.*.source and
+// containers.*.metrics[].other.content as JSON strings wrapping JSON objects, which
+// the generated SDK types reject. Raw passthrough must survive that untouched.
+func TestSearchAdvisoryRawPassthrough(t *testing.T) {
+	got, _, err := runAdvisoryHandler(t,
+		searchAdvisoryArgs{Vendor: "anthropics"},
+		func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+			return advisoryResult(1, advisoryRefWithSource("CVE-2025-59532")), nil
+		})
+
+	require.NoError(t, err, "a record the SDK types cannot decode must still be returned")
+	require.Len(t, got.Data, 1)
+	assert.Equal(t, []string{"CVE-2025-59532"}, cveIDs(t, got.Data),
+		"identity is still readable for de-duplication")
+
+	var record struct {
+		Containers struct {
+			Cna struct {
+				Source string `json:"source"`
+			} `json:"cna"`
+		} `json:"containers"`
+	}
+	require.NoError(t, json.Unmarshal(got.Data[0], &record))
+	assert.JSONEq(t,
+		`{"advisory":"GHSA-w5fx-fh39-j5rw","discovery":"UNKNOWN"}`,
+		record.Containers.Cna.Source,
+		"the double-encoded value reaches the model byte-for-byte, unrepaired")
+}
+
+// TestSearchAdvisoryDeterminism guards the response against map-iteration order
+// leaking into the output.
+func TestSearchAdvisoryDeterminism(t *testing.T) {
+	respond := func(q client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+		if q.Vendor == "Anthropic" {
+			return advisoryResult(25, advisoryRef("CVE-B", "Beta", "Gamma")), nil
+		}
+		return advisoryResult(25, advisoryRef("CVE-A", "Alpha")), nil
+	}
+
+	first, _, err := runAdvisoryHandler(t, searchAdvisoryArgs{Vendor: "anthropic", Product: "nope"}, respond)
+	require.NoError(t, err)
+	second, _, err := runAdvisoryHandler(t, searchAdvisoryArgs{Vendor: "anthropic", Product: "nope"}, respond)
+	require.NoError(t, err)
+
+	a, err := json.Marshal(first)
+	require.NoError(t, err)
+	b, err := json.Marshal(second)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(a), string(b))
 }


### PR DESCRIPTION
Vendor and product queries against `v4_search_advisory` returned zero rows while matching advisories existed, which reads as "no vulnerabilities" rather than as an error.

**Changes**

- `internal/client/search_advisory.go` — call `/v4/advisory` directly, carry records as `json.RawMessage`. The generated SDK types fail on ~80% of responses: `containers.*.source` and `metrics[].other.content` arrive as JSON strings wrapping objects, declared `[]int32` and `map[string]interface{}`. Mirrors `SearchIndex`; the SDK is unchanged for the other 13 calls.
- `limit` — default 1 → 100 (the upstream maximum), and now means rows returned rather than upstream page size. The API filters after slicing a page, so a small limit withheld matches instead of returning fewer, and which records it withheld shifted with the page size requested. Nothing is capped on row count now; the byte bound is the only limit. An explicit limit is honoured exactly and trimming to it is disclosed.
- Vendor fan-out — upstream compares vendor with a case-sensitive `==`, so `anthropic` and `Anthropic` return different subsets. Retries as-given, lowercased and capitalised, then unions. Page widened to cover `total`, since the filter sees one page and its ordering is unstable between calls; rows interleaved so trimming can't drop a whole spelling.
- Product fallback — products are CNA prose (`Claude Desktop - Windows`), matched exactly. If the vendor resolves but the product doesn't, the filter is dropped and real names returned in `products_found`.
- Byte bound (`maxResponseBytes = 80_000`) — record sizes vary 1000×; `vendor=linux` returned 6.2 MB. Whole rows dropped rather than abridged, oversized rows skipped rather than ending the walk, dropped IDs listed in `dropped_cves`.
- Response gains `returned`, `dropped_for_size`, `dropped_cves`, `vendors_tried`, `vendors_failed`, `products_found`, `notes` — all `omitempty`, so an un-widened response keeps the existing shape. `next_cursor` is dropped from a union.
- Descriptions only (`get_cpe_cves`, `docs/tools.md`) — CPE attributes accept `*` and `?` wildcards, which was already supported and undiscoverable.

**Testing**

`make test && make lint` clean, `go test -race ./...` green. 20 new/expanded server-layer cases, 7 client-layer, including a fixture carrying the double-encoded `source` the SDK types reject.

Driven through the built binary against the live API: `vendor=anthropic` goes from 1 CVE to 24, `vendor=openai` from 0 to 1, `vendor=anthropic&product=claude` from 0 to 24, and `vendor=anthropics`/`vendor=OpenAI` from decode errors to 25 and 5. Run 3× each since unstable page ordering makes a single pass unreliable. Across 20 vendors: 0 errors, worst response ~20k tokens against the 80 KB budget.

(The vendor fan-out works around the upstream case-sensitive comparison and should be removed once the API matches case-insensitively; the limit, byte bound and product fallback address separate defects and stay useful regardless.)
