### PR TITLE
fix(instructions): Stop routing exposure questions to search_cve

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,12 +39,35 @@ var tools = []func(*mcp.Server, client.Client){
 	registerGetAdvisoryBackup,
 }
 
-// adds a sufficiency signal (search_cve already aggregates the category data)
-// and narrows the search_index carve-out to explicit raw-record requests
-const serverInstructions = `For CVE questions, use search_cve as the default tool — it already aggregates advisories, exploits, threat intelligence, and KEV status across all indices, so a question mentioning those categories is fully answered by search_cve alone. ` +
-	`Do not autonomously paginate, or call search_index to cross-check, enrich, or gather a category of data. ` +
-	`Call search_index only when the user explicitly asks to query a specific named index for its raw record (e.g. "show me the NVD2 record", "query the vulncheck-kev index directly"). ` +
-	`When the user explicitly asks for more results or the next page, paginate using the cursor.`
+// serverInstructions routes tool choice by the subject of the question.
+//
+// search_cve aggregates a broad set of indices spanning advisories, exploits,
+// threat intelligence and KEV, but it reaches none of the Target Intelligence, IP
+// Intelligence or Canary Intelligence indices. Those three hold the only data that answers exposure and
+// observed-attack questions, so the blanket search_index prohibition added for
+// #39 — to stop clients autonomously fanning out — has to name them as
+// exceptions. Without that, a question about internet exposure or in-the-wild
+// exploitation is answered from indices carrying no such data, and answered
+// confidently.
+//
+// Only the cve and date filters reach these indices today. The index-specific
+// filters they also accept upstream (asn, cidr, country, vendor, product, port,
+// classifications, src_country, ...) are not yet exposed by search_index; they
+// arrive with the dedicated product tools.
+const serverInstructions = `Route by what the question is about.
+
+CVE metadata — severity, exploit availability and maturity, KEV status, advisories, threat actor, ransomware and botnet association: use search_cve. It aggregates these categories across many indices and is normally sufficient on its own. Do not call search_index to cross-check or enrich what it returns.
+
+Internet exposure and observed attack activity: search_cve does not cover these. Use search_index against the index that holds the data:
+- target-intel — internet-facing hosts confirmed to be running vulnerable software. Answers "which hosts are exposed to this CVE".
+- ipintel-3d, ipintel-10d, ipintel-30d, ipintel-90d — attacker and target IP infrastructure: C2, honeypots and initial-access targets over a rolling window.
+- vulncheck-canaries, or vulncheck-canaries-3d, -10d, -30d, -90d for a recent window — exploitation attempts observed against VulnCheck's own deliberately vulnerable canary hosts. Answers "is this CVE being exploited in the wild, and by whom".
+
+These three describe populations of hosts and events rather than one record per CVE. Pass an explicit limit, because the default of 1 is not a meaningful answer to a population question. Read the population size from the response total and report that, rather than counting the rows returned. Do not paginate in order to enumerate them.
+
+Otherwise call search_index only when the user explicitly asks for a specific named index's raw record, e.g. "show me the NVD2 record".
+
+Do not paginate autonomously. When the user asks for more results or the next page, use the cursor.`
 
 func New(vc client.Client, version string, cache *mcp.SchemaCache) *mcp.Server {
 	srv := mcp.NewServer(

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -38,3 +38,37 @@ func TestNewServer_ToolsRegistered(t *testing.T) {
 	assert.Contains(t, names, "get_cpe_cves")
 	assert.Contains(t, names, "search_cpe")
 }
+
+// TestServerInstructions_RoutesExposureQuestionsAwayFromSearchCVE guards the
+// routing contract, not the prose. search_cve is served by /v3/search/cve, whose
+// index set does not include target-intel, ipintel-* or vulncheck-canaries*, so
+// the instructions must not claim it answers exposure or observed-attack
+// questions, and must name the indices that do.
+func TestServerInstructions_RoutesExposureQuestionsAwayFromSearchCVE(t *testing.T) {
+	t.Run("names the indices search_cve cannot reach", func(t *testing.T) {
+		for _, index := range []string{"target-intel", "ipintel-3d", "vulncheck-canaries"} {
+			assert.Contains(t, serverInstructions, index,
+				"instructions must name %q, the only source for exposure or observed-attack questions", index)
+		}
+	})
+
+	t.Run("does not claim search_cve is sufficient for every category", func(t *testing.T) {
+		// The prior wording promised a question mentioning threat intelligence was
+		// "fully answered by search_cve alone", which is false for the three indices
+		// above and left them unreachable in practice.
+		assert.NotContains(t, serverInstructions, "fully answered by search_cve alone")
+		assert.Contains(t, serverInstructions, "search_cve does not cover these")
+	})
+
+	t.Run("keeps the fan-out and pagination guardrails from #39", func(t *testing.T) {
+		assert.Contains(t, serverInstructions, "Do not paginate autonomously")
+		assert.Contains(t, serverInstructions, "Do not call search_index to cross-check or enrich")
+	})
+
+	t.Run("warns that the default limit is not a population answer", func(t *testing.T) {
+		// search_index defaults limit to 1, which is misleading rather than merely
+		// small when the question is "which hosts are exposed".
+		assert.Contains(t, serverInstructions, "Pass an explicit limit")
+		assert.Contains(t, serverInstructions, "population size from the response total")
+	})
+}


### PR DESCRIPTION
First of four stacked PRs. **Base: `main`.**

## Problem

The server instructions told the model that a question mentioning threat intelligence was "fully answered by `search_cve` alone", and separately forbade calling `search_index` "to cross-check, enrich, or gather a category of data".

Both halves are load-bearing, and the first is wrong. `search_cve` aggregates a broad set of indices, but the Target Intelligence, IP Intelligence and Canary Intelligence indices are not among them — confirmed by querying it directly and checking which indices the hits come from. Those three carry the only data that answers "which hosts are exposed to this CVE" and "is this being exploited in the wild".

So a question about exposure or observed attack activity was answered from sources holding none of it, while the prohibition kept the model away from the ones that did. It produced a confident answer assembled from the wrong places.

## Change

Route by the subject of the question rather than by category of data:

- CVE metadata (severity, exploit maturity, KEV status, advisories, actor association) → `search_cve`
- exposure and observed attack activity → the indices that actually hold it

The fan-out and pagination guardrails added for #39 are kept as they were. The exposure indices are named as explicit exceptions rather than the carve-out being widened, so the behaviour that #39 fixed is unchanged.

Also notes that these indices describe populations rather than one record per CVE, so the model should pass an explicit limit — `search_index` returns a single row by default, which is misleading rather than merely small for a population question — and should report the total from the response instead of counting the rows it received.

## Notes for review

- The instruction text is now a raw string with real newlines instead of concatenated literals. It reads better and models parse the structure well, but it does make the diff look larger than the change is.
- Adds the first test over this string. It asserts the routing contract rather than the prose, since the wording will keep evolving but the guarantees should not. Nothing covered it before, and it silently changes model behaviour.
- PR 3 in this stack supersedes part of this text once the dedicated product tools exist. That is expected and called out in the commit message.

`make test && make lint` pass.
