### PR TITLE
refactor(server): Extract response byte-bounding into a reusable helper

### DIFF
--- a/internal/server/bound.go
+++ b/internal/server/bound.go
@@ -1,0 +1,105 @@
+package server
+
+import "encoding/json"
+
+// maxResponseBytes bounds a serialized tool response at roughly 20k tokens.
+//
+// `limit` bounds the number of rows, not their size, and record sizes vary
+// enormously between indices: a single record from one index can outweigh a full
+// page from another. Without a byte bound a broad query can consume most of a
+// client's context, so rows are dropped whole until the response fits and the count
+// dropped is reported.
+const maxResponseBytes = 80_000
+
+// rowBound describes a response whose row list may be trimmed to fit a byte budget.
+type rowBound struct {
+	// Envelope is the full response, rows included. It is marshalled once to
+	// measure the fixed overhead around Rows, so the budget accounts for whatever
+	// notes and metadata the caller has already attached.
+	Envelope any
+
+	// Rows are the records under consideration, carried raw so they need no
+	// re-encoding to measure.
+	Rows []json.RawMessage
+
+	// MaxBytes is the ceiling for the serialized envelope. Zero means maxResponseBytes.
+	MaxBytes int
+
+	// Identify optionally names a dropped row — a CVE ID, an IP, whatever lets the
+	// caller fetch it individually afterwards. Returning "" omits the row from Names.
+	Identify func(json.RawMessage) string
+
+	// MaxNamed caps how many dropped rows are named, so a large drop cannot itself
+	// flood the response. Zero means no names are collected.
+	MaxNamed int
+}
+
+// boundResult is the outcome of trimming: the rows that fit, how many did not, and
+// the names of those that did not (up to MaxNamed).
+type boundResult struct {
+	Kept    []json.RawMessage
+	Dropped int
+	Names   []string
+}
+
+// boundRows drops whole rows until the marshalled envelope fits inside the budget.
+//
+// Rows are never abridged: a partial record would be indistinguishable from a
+// complete one and could be read as authoritative. An oversized row is skipped
+// rather than ending the walk, so one enormous record cannot hide the smaller ones
+// behind it, which is why keeping "at least one row" is not a safe floor.
+//
+// The caller is responsible for assigning Kept back onto its response and for
+// wording whatever note explains the drop; the phrasing that helps a model recover
+// is specific to the tool, so this returns facts rather than prose.
+func boundRows(b rowBound) boundResult {
+	if len(b.Rows) == 0 {
+		return boundResult{Kept: b.Rows}
+	}
+
+	maxBytes := b.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = maxResponseBytes
+	}
+
+	encoded, err := json.Marshal(b.Envelope)
+	if err != nil || len(encoded) <= maxBytes {
+		return boundResult{Kept: b.Rows}
+	}
+
+	// Budget only the rows; the surrounding envelope and notes are small and fixed.
+	budget := maxBytes - (len(encoded) - rowsSize(b.Rows))
+	kept := make([]json.RawMessage, 0, len(b.Rows))
+	var names []string
+	used := 0
+
+	for _, raw := range b.Rows {
+		size := len(raw) + 1 // the comma that joins it to the previous row
+		if used+size > budget {
+			if b.Identify != nil && len(names) < b.MaxNamed {
+				if name := b.Identify(raw); name != "" {
+					names = append(names, name)
+				}
+			}
+			continue
+		}
+		used += size
+		kept = append(kept, raw)
+	}
+
+	return boundResult{
+		Kept:    kept,
+		Dropped: len(b.Rows) - len(kept),
+		Names:   names,
+	}
+}
+
+// rowsSize reports the serialized size of the row list. Raw records need no
+// re-encoding, so this is just their lengths plus the separators.
+func rowsSize(data []json.RawMessage) int {
+	size := 2 // the enclosing brackets
+	for _, raw := range data {
+		size += len(raw) + 1
+	}
+	return size
+}

--- a/internal/server/bound_test.go
+++ b/internal/server/bound_test.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testEnvelope mirrors the shape every bounded tool response shares: a row list
+// plus some fixed metadata that also has to fit inside the budget.
+type testEnvelope struct {
+	Data  []json.RawMessage `json:"data"`
+	Total int               `json:"total"`
+	Notes []string          `json:"notes,omitempty"`
+}
+
+// row builds a record of approximately size bytes, tagged with an id so drops can
+// be attributed.
+func row(id string, size int) json.RawMessage {
+	pad := max(size-len(id)-20, 1)
+	return json.RawMessage(fmt.Sprintf(`{"id":%q,"p":%q}`, id, strings.Repeat("x", pad)))
+}
+
+func idOf(raw json.RawMessage) string {
+	var r struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(raw, &r)
+	return r.ID
+}
+
+func TestBoundRows_LeavesResponsesThatAlreadyFit(t *testing.T) {
+	rows := []json.RawMessage{row("a", 100), row("b", 100)}
+	env := &testEnvelope{Data: rows, Total: 2}
+
+	got := boundRows(rowBound{Envelope: env, Rows: rows, MaxBytes: 10_000})
+
+	assert.Equal(t, 0, got.Dropped)
+	assert.Empty(t, got.Names)
+	assert.Len(t, got.Kept, 2)
+}
+
+func TestBoundRows_EmptyRowsIsANoOp(t *testing.T) {
+	env := &testEnvelope{Total: 0}
+
+	got := boundRows(rowBound{Envelope: env, Rows: nil, MaxBytes: 1})
+
+	assert.Equal(t, 0, got.Dropped)
+	assert.Empty(t, got.Kept)
+}
+
+func TestBoundRows_DropsWholeRowsUntilTheResponseFits(t *testing.T) {
+	rows := make([]json.RawMessage, 20)
+	for i := range rows {
+		rows[i] = row(fmt.Sprintf("cve-%d", i), 1_000)
+	}
+	env := &testEnvelope{Data: rows, Total: 20}
+	const budget = 5_000
+
+	got := boundRows(rowBound{Envelope: env, Rows: rows, MaxBytes: budget, Identify: idOf, MaxNamed: 50})
+
+	require.NotEmpty(t, got.Kept, "a budget larger than one row must keep some rows")
+	assert.Equal(t, len(rows)-len(got.Kept), got.Dropped)
+
+	// Every kept row is intact — trimming never abridges a record.
+	for _, raw := range got.Kept {
+		assert.True(t, json.Valid(raw), "kept rows must remain valid JSON")
+	}
+
+	env.Data = got.Kept
+	encoded, err := json.Marshal(env)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(encoded), budget, "trimmed response must fit the budget")
+}
+
+// A single enormous record must not end the walk, or it would hide every smaller
+// row behind it and the caller would see one row where it could have had many.
+func TestBoundRows_SkipsAnOversizedRowAndKeepsTheSmallerOnesBehindIt(t *testing.T) {
+	rows := []json.RawMessage{
+		row("huge", 40_000),
+		row("small-1", 200),
+		row("small-2", 200),
+	}
+	env := &testEnvelope{Data: rows, Total: 3}
+
+	got := boundRows(rowBound{Envelope: env, Rows: rows, MaxBytes: 2_000, Identify: idOf, MaxNamed: 10})
+
+	assert.Equal(t, 1, got.Dropped)
+	assert.Equal(t, []string{"huge"}, got.Names)
+
+	kept := make([]string, 0, len(got.Kept))
+	for _, raw := range got.Kept {
+		kept = append(kept, idOf(raw))
+	}
+	assert.Equal(t, []string{"small-1", "small-2"}, kept)
+}
+
+func TestBoundRows_CapsHowManyDroppedRowsAreNamed(t *testing.T) {
+	rows := make([]json.RawMessage, 30)
+	for i := range rows {
+		rows[i] = row(fmt.Sprintf("cve-%d", i), 2_000)
+	}
+	env := &testEnvelope{Data: rows, Total: 30}
+
+	got := boundRows(rowBound{Envelope: env, Rows: rows, MaxBytes: 3_000, Identify: idOf, MaxNamed: 4})
+
+	assert.Greater(t, got.Dropped, 4, "this budget must drop more rows than MaxNamed")
+	assert.Len(t, got.Names, 4, "names are capped so a large drop cannot flood the response")
+}
+
+func TestBoundRows_CollectsNoNamesWithoutAnIdentifier(t *testing.T) {
+	rows := []json.RawMessage{row("a", 5_000), row("b", 5_000)}
+	env := &testEnvelope{Data: rows, Total: 2}
+
+	got := boundRows(rowBound{Envelope: env, Rows: rows, MaxBytes: 1_000})
+
+	assert.Positive(t, got.Dropped)
+	assert.Empty(t, got.Names, "Identify is optional")
+}
+
+// The budget covers the whole envelope, so metadata the caller has already attached
+// leaves less room for rows. Without this, a response with many notes could still
+// overflow after trimming.
+func TestBoundRows_AccountsForEnvelopeOverhead(t *testing.T) {
+	rows := make([]json.RawMessage, 10)
+	for i := range rows {
+		rows[i] = row(fmt.Sprintf("r-%d", i), 500)
+	}
+	const budget = 4_000
+
+	bare := boundRows(rowBound{Envelope: &testEnvelope{Data: rows, Total: 10}, Rows: rows, MaxBytes: budget})
+
+	noisy := &testEnvelope{Data: rows, Total: 10, Notes: []string{strings.Repeat("n", 2_000)}}
+	withNotes := boundRows(rowBound{Envelope: noisy, Rows: rows, MaxBytes: budget})
+
+	assert.Less(t, len(withNotes.Kept), len(bare.Kept),
+		"a bulkier envelope must leave room for fewer rows")
+
+	noisy.Data = withNotes.Kept
+	encoded, err := json.Marshal(noisy)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(encoded), budget)
+}
+
+func TestBoundRows_DefaultsToMaxResponseBytes(t *testing.T) {
+	rows := make([]json.RawMessage, 200)
+	for i := range rows {
+		rows[i] = row(fmt.Sprintf("r-%d", i), 2_000)
+	}
+	env := &testEnvelope{Data: rows, Total: 200}
+
+	got := boundRows(rowBound{Envelope: env, Rows: rows}) // MaxBytes unset
+
+	assert.Positive(t, got.Dropped, "400 KB of rows must be trimmed against the default budget")
+
+	env.Data = got.Kept
+	encoded, err := json.Marshal(env)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(encoded), maxResponseBytes)
+}
+
+func TestRowsSize_MatchesTheSerializedRowList(t *testing.T) {
+	rows := []json.RawMessage{row("a", 120), row("b", 340)}
+
+	encoded, err := json.Marshal(rows)
+	require.NoError(t, err)
+
+	// rowsSize counts a separator after every row rather than between them, so it
+	// overshoots by exactly one byte — deliberate, since it is used as a floor.
+	assert.Equal(t, len(encoded)+1, rowsSize(rows))
+}

--- a/internal/server/search_advisory.go
+++ b/internal/server/search_advisory.go
@@ -64,15 +64,6 @@ const (
 	// maxListedProducts caps the product names reported when the product filter is
 	// dropped, so a large vendor cannot flood the response.
 	maxListedProducts = 25
-
-	// maxResponseBytes bounds the serialized response at roughly 20k tokens.
-	//
-	// `limit` bounds the number of rows, not their size, and advisory records vary by
-	// three orders of magnitude: a ten-row page for a large vendor has been measured
-	// at 6.2 MB (~1.5M tokens), and a single record can exceed 150 KB. Without a byte
-	// bound a widened search can destroy the caller's context, so rows are dropped
-	// whole until the response fits and the count dropped is reported.
-	maxResponseBytes = 80_000
 )
 
 const (
@@ -172,7 +163,7 @@ func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdviso
 			}
 		}
 
-		if dropped, ids := capResponseBytes(&response); dropped > 0 {
+		if dropped, ids := capAdvisoryBytes(&response); dropped > 0 {
 			response.Dropped = dropped
 			response.DroppedCVEs = ids
 			response.Notes = append(response.Notes, truncatedNote)
@@ -194,57 +185,24 @@ func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdviso
 	}
 }
 
-// capResponseBytes drops whole rows until the response fits inside
-// maxResponseBytes, returning how many were dropped and naming them.
-//
-// Rows are never abridged: a partial advisory record would be indistinguishable
-// from a complete one and could be read as authoritative. An oversized row is
-// skipped rather than ending the walk, so one enormous record cannot hide the
-// smaller ones behind it — a single advisory has been measured at ~700 KB alone,
-// which is why keeping "at least one row" is not a safe floor here. Dropped rows
-// are named so the caller can fetch them individually by cve_id.
-func capResponseBytes(response *searchAdvisoryResponse) (int, []string) {
-	if response.SearchAdvisoryResult == nil || len(response.Data) == 0 {
+// capAdvisoryBytes trims the response to the shared byte budget, naming dropped
+// records by CVE ID so the caller can fetch them individually afterwards.
+func capAdvisoryBytes(response *searchAdvisoryResponse) (int, []string) {
+	if response.SearchAdvisoryResult == nil {
 		return 0, nil
 	}
 
-	encoded, err := json.Marshal(response)
-	if err != nil || len(encoded) <= maxResponseBytes {
-		return 0, nil
-	}
+	bound := boundRows(rowBound{
+		Envelope: response,
+		Rows:     response.Data,
+		Identify: func(raw json.RawMessage) string {
+			return parseAdvisoryRecord(raw).CveMetadata.CveID
+		},
+		MaxNamed: maxListedProducts,
+	})
 
-	// Budget only the rows; the surrounding envelope and notes are small and fixed.
-	budget := maxResponseBytes - (len(encoded) - rowsSize(response.Data))
-	kept := make([]json.RawMessage, 0, len(response.Data))
-	var dropped []string
-	used := 0
-
-	for _, raw := range response.Data {
-		size := len(raw) + 1 // the comma that joins it to the previous row
-		if used+size > budget {
-			record := parseAdvisoryRecord(raw)
-			if id := record.CveMetadata.CveID; id != "" && len(dropped) < maxListedProducts {
-				dropped = append(dropped, id)
-			}
-			continue
-		}
-		used += size
-		kept = append(kept, raw)
-	}
-
-	count := len(response.Data) - len(kept)
-	response.Data = kept
-	return count, dropped
-}
-
-// rowsSize reports the serialized size of the row list. Raw records need no
-// re-encoding, so this is just their lengths plus the separators.
-func rowsSize(data []json.RawMessage) int {
-	size := 2 // the enclosing brackets
-	for _, raw := range data {
-		size += len(raw) + 1
-	}
-	return size
+	response.Data = bound.Kept
+	return bound.Dropped, bound.Names
 }
 
 func advisoryQuery(args searchAdvisoryArgs) client.SearchAdvisoryQuery {


### PR DESCRIPTION
Second of four stacked PRs. **Base: `3248-correct-server-instructions-routing`.**

Pure refactor — no behaviour change.

## Problem

`v4_search_advisory` was the only tool that bounded its response size, and the machinery was welded to its own response type: `capResponseBytes` took `*searchAdvisoryResponse`, while `rowsSize` and the byte budget lived in the same file. Every other list-returning tool passes raw upstream JSON straight through.

That does not hold up as more tools need it. Record sizes vary enormously between indices, and a single page from a large one can consume most of a client's context.

## Change

Lifts the logic into `bound.go` as `boundRows`, preserving the existing behaviour exactly:

- rows are dropped **whole, never abridged** — a partial record is indistinguishable from a complete one and could be read as authoritative
- an oversized row is **skipped rather than ending the walk**, so one large record cannot hide the smaller ones behind it
- the budget covers the **whole envelope**, so notes already attached correctly leave less room for rows
- dropped rows are named through a caller-supplied `Identify` func, so the helper no longer needs to know what a CVE ID is

It returns facts rather than prose. The wording that helps a model recover from a truncated response is specific to the tool, so each caller keeps ownership of its own note text and `truncatedNote` stays where it was.

`v4_search_advisory` now calls it through a thin `capAdvisoryBytes` adapter.

## Notes for review

- **The no-behaviour-change proof is that the existing advisory test suite is untouched and still passes.** Worth checking that claim holds — it is the main thing to verify here.
- Adds 9 tests for the helper itself, including envelope-overhead accounting and the oversized-row-skip case.
- This **prepares** bounding for `search_index` rather than delivering it. Applying a byte bound there still needs the single-document case resolved: dropping whole rows from an index that returns one document per CVE leaves nothing, and that response is not free to be reshaped. That design decision is still open and deliberately not settled here.
