### PR TITLE
feat(tools): Expose threat-intelligence filters on search_index

### DIFF
--- a/internal/client/search_index.go
+++ b/internal/client/search_index.go
@@ -74,6 +74,10 @@ type SearchIndexQuery struct {
 	MispID      string
 	Ransomware  string
 	Botnet      string
+
+	// JVNDB is the Japanese vulnerability database identifier, e.g.
+	// "JVNDB-2025-007355".
+	JVNDB string
 }
 
 type indexResponseMeta struct {
@@ -134,6 +138,7 @@ func (c *VulncheckClient) SearchIndex(ctx context.Context, q SearchIndexQuery) (
 		"misp_id":            q.MispID,
 		"ransomware":         q.Ransomware,
 		"botnet":             q.Botnet,
+		"jvndb":              q.JVNDB,
 	} {
 		if value != "" {
 			p.Set(key, value)

--- a/internal/client/search_index_test.go
+++ b/internal/client/search_index_test.go
@@ -296,3 +296,23 @@ func TestSearchIndex_OmitsZeroPort(t *testing.T) {
 	_, present := got["port"]
 	assert.False(t, present)
 }
+
+// jvndb reaches the API under its own key like the other identifier filters.
+func TestSearchIndex_SendsJVNDB(t *testing.T) {
+	var got url.Values
+	c := newAPITestClient(func(r *http.Request) (*http.Response, error) {
+		got = r.URL.Query()
+		return jsonResp(http.StatusOK, map[string]any{
+			"_meta": map[string]any{"total_documents": 1},
+			"data":  []any{},
+		}), nil
+	})
+
+	_, err := c.SearchIndex(context.Background(), SearchIndexQuery{
+		Index: "vulncheck-nvd2",
+		JVNDB: "JVNDB-2025-007355",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "JVNDB-2025-007355", got.Get("jvndb"))
+}

--- a/internal/server/search_index.go
+++ b/internal/server/search_index.go
@@ -21,6 +21,12 @@ type searchIndexArgs struct {
 	UpdatedAtStartDate string `json:"updated_at_start_date,omitempty" jsonschema:"Filter by data source update date range start (YYYY-MM-DD)"`
 	UpdatedAtEndDate   string `json:"updated_at_end_date,omitempty"   jsonschema:"Filter by data source update date range end (YYYY-MM-DD)"`
 	Date               string `json:"date,omitempty"                  jsonschema:"Filter by exact date (YYYY-MM-DD) — equivalent to setting both start and end to the same date"`
+	ThreatActor        string `json:"threat_actor,omitempty"          jsonschema:"Filter by threat actor name, e.g. 'UNC2630'. Valid on the threat-actors, botnets, ransomware, exploits and vulnerability indices"`
+	MitreID            string `json:"mitre_id,omitempty"              jsonschema:"Filter by a threat actor's MITRE ATT&CK group ID, e.g. 'G0013'"`
+	MispID             string `json:"misp_id,omitempty"               jsonschema:"Filter by a threat actor's MISP ID"`
+	Ransomware         string `json:"ransomware,omitempty"            jsonschema:"Filter by ransomware group name, e.g. 'Cactus'"`
+	Botnet             string `json:"botnet,omitempty"                jsonschema:"Filter by botnet name, e.g. 'Fbot'"`
+	JVNDB              string `json:"jvndb,omitempty"                 jsonschema:"Filter by Japanese vulnerability database ID, e.g. 'JVNDB-2025-007355'"`
 	Sort               string `json:"sort,omitempty"                  jsonschema:"Sort results by '_timestamp' or 'date_added'"`
 	Order              string `json:"order,omitempty"                 jsonschema:"Sort direction: 'asc' or 'desc'"`
 	Limit              int    `json:"limit,omitempty"                 jsonschema:"Number of results per page (default 1)"`
@@ -29,9 +35,11 @@ type searchIndexArgs struct {
 }
 
 var SearchIndexTool = &mcp.Tool{
-	Name:        "search_index",
-	Title:       "Search Index",
-	Description: "Query a VulnCheck index by name (required). Use list_indices to discover available index names. Filter by CVE, alias, IAVA, date ranges, and more. Supports sorting and cursor-based pagination.",
+	Name:  "search_index",
+	Title: "Search Index",
+	Description: "Query a VulnCheck index by name (required). Use list_indices to discover available index names. " +
+		"Filter by CVE, alias, IAVA, JVNDB ID, threat actor, MITRE ATT&CK group, MISP ID, ransomware group, botnet, and date ranges. Supports sorting and cursor-based pagination. " +
+		"For IP Intelligence, Target Intelligence and Canary Intelligence use search_ip_intel, search_target_intel and search_canaries instead — they expose host and network filters this tool does not.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
@@ -69,6 +77,12 @@ func MakeSearchIndexHandler(vc client.Client) mcp.ToolHandlerFor[searchIndexArgs
 			Date:               args.Date,
 			Alias:              args.Alias,
 			IAVA:               args.IAVA,
+			ThreatActor:        args.ThreatActor,
+			MitreID:            args.MitreID,
+			MispID:             args.MispID,
+			Ransomware:         args.Ransomware,
+			Botnet:             args.Botnet,
+			JVNDB:              args.JVNDB,
 			Sort:               args.Sort,
 			Order:              args.Order,
 		})

--- a/internal/server/search_index_test.go
+++ b/internal/server/search_index_test.go
@@ -92,3 +92,45 @@ func TestMakeSearchIndexHandler(t *testing.T) {
 		})
 	}
 }
+
+// TestMakeSearchIndexHandler_ThreatIntelFilters covers the filters shared by the
+// vulnerability, exploit and threat-intelligence indices, which were previously
+// unreachable through this tool. Each one was confirmed against the API before
+// being exposed.
+func TestMakeSearchIndexHandler_ThreatIntelFilters(t *testing.T) {
+	var got client.SearchIndexQuery
+	vc := &mockClient{
+		searchIndexFn: func(_ context.Context, q client.SearchIndexQuery) (*client.IndexQueryResult, error) {
+			got = q
+			return &client.IndexQueryResult{Data: []json.RawMessage{}}, nil
+		},
+	}
+
+	_, _, err := MakeSearchIndexHandler(vc)(context.Background(), nil, searchIndexArgs{
+		Index:       "threat-actors",
+		ThreatActor: "UNC2630",
+		MitreID:     "G0013",
+		MispID:      "3570552c-c46f-428e-9472-744a14e6ece7",
+		Ransomware:  "Cactus",
+		Botnet:      "Fbot",
+		JVNDB:       "JVNDB-2025-007355",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "threat-actors", got.Index)
+	assert.Equal(t, "UNC2630", got.ThreatActor)
+	assert.Equal(t, "G0013", got.MitreID)
+	assert.Equal(t, "3570552c-c46f-428e-9472-744a14e6ece7", got.MispID)
+	assert.Equal(t, "Cactus", got.Ransomware)
+	assert.Equal(t, "Fbot", got.Botnet)
+	assert.Equal(t, "JVNDB-2025-007355", got.JVNDB)
+}
+
+// The product indices have dedicated tools that expose host and network filters
+// this one cannot, so the description has to send callers there rather than leaving
+// them to discover the worse path.
+func TestSearchIndexTool_PointsAtTheProductTools(t *testing.T) {
+	for _, tool := range []string{"search_ip_intel", "search_target_intel", "search_canaries"} {
+		assert.Contains(t, SearchIndexTool.Description, tool)
+	}
+}


### PR DESCRIPTION
Fourth of four stacked PRs. **Base: `3248-product-index-tools`.**

## Problem

Closes out the parameter gap the product tools were built to address. Those cover the flagship indices, but the same limitation applied elsewhere: the vulnerability, exploit and threat-intelligence indices share a set of filters — threat actor, MITRE ATT&CK group, MISP ID, ransomware group, botnet, and JVNDB identifier — and none was reachable through `search_index`.

Those indices are not getting dedicated tools, so `search_index` is where the filters belong.

## Change

Adds the six filters to `search_index`, serving the eight indices that share them.

The tool description now also points at `search_ip_intel`, `search_target_intel` and `search_canaries`, so a caller reaching for an index that has a dedicated tool is sent to the better path.

## Notes for review

- **Each filter was confirmed to narrow results against the live API before being exposed**, by comparing a filtered query against its unfiltered baseline for that index. Parameters that did not narrow are not exposed and have no field on the query type.
- That check is empirical rather than declarative on purpose: the set of parameters an index advertises is not by itself sufficient evidence that each one is applied, so exposing a filter without confirming it would risk returning an unfiltered result that looks filtered.
- No change to `search_index`'s default page size in this PR. It still returns a single row by default, which is right for the single-record lookups it is now mostly used for, and the product tools handle the population questions.
