### PR TITLE
fix(tools): Distinguish an empty page from an absence of data

### DIFF
--- a/internal/server/product_index.go
+++ b/internal/server/product_index.go
@@ -35,6 +35,10 @@ const (
 	productTruncatedNote = "rows were dropped whole to keep this response within a usable context " +
 		"budget, never abridged — narrow the query with more filters, or lower limit, to see a " +
 		"different slice"
+
+	emptyPageNote = "records match this query but none was returned on this page: the API applies the " +
+		"filter to a page after slicing it, so a small limit can yield nothing while total is " +
+		"non-zero. This is not an absence of data — retry with a larger limit"
 )
 
 // windowedIndex resolves a window token to a concrete index name.
@@ -115,7 +119,14 @@ func newProductResponse(index string, result *client.IndexQueryResult) productRe
 		response.DroppedIPs = bound.Names
 		response.Notes = append(response.Notes, productTruncatedNote)
 	}
-	if response.Total > response.Returned {
+	// An empty page with a non-zero total is not the same as no data, and must not be
+	// reported as a sample: the filter is applied to a page after it is sliced, so a
+	// small limit can legitimately yield nothing. Saying so is the difference between
+	// "nothing matches" and "ask again for more".
+	switch {
+	case response.Returned == 0 && response.Total > 0:
+		response.Notes = append(response.Notes, emptyPageNote)
+	case response.Total > response.Returned:
 		response.Notes = append(response.Notes, populationNote)
 	}
 	if response.Total > offsetCeiling {

--- a/internal/server/product_index_test.go
+++ b/internal/server/product_index_test.go
@@ -378,3 +378,43 @@ func TestSearchTargetIntelHandler_SerializesTheProductEnvelope(t *testing.T) {
 	assert.JSONEq(t, `{"ip":"203.0.113.42","port":443}`, string(payload.Data[0]))
 	assert.NotEmpty(t, payload.Notes, "one row out of 559290 must carry the sampling caveat")
 }
+
+// An empty page with a non-zero total is not an absence of data. The API applies
+// its filter to a page after slicing it, so a small limit can legitimately return
+// nothing while records match. Reporting that as a sample would tell the caller it
+// had seen representative rows when it had seen none.
+func TestNewProductResponse_DistinguishesAnEmptyPageFromNoData(t *testing.T) {
+	t.Run("empty page with matches says so, and does not claim a sample", func(t *testing.T) {
+		got := newProductResponse("target-intel", &client.IndexQueryResult{
+			Data:  []json.RawMessage{},
+			Total: 403,
+		})
+
+		assert.Zero(t, got.Returned)
+		notes := strings.Join(got.Notes, " ")
+		assert.Contains(t, notes, "retry with a larger limit",
+			"an empty page with matches must tell the caller how to recover")
+		assert.NotContains(t, notes, "these rows are a sample",
+			"there are no rows, so calling them a sample is misleading")
+	})
+
+	t.Run("genuinely empty result stays quiet", func(t *testing.T) {
+		got := newProductResponse("target-intel", &client.IndexQueryResult{
+			Data:  []json.RawMessage{},
+			Total: 0,
+		})
+
+		assert.Zero(t, got.Returned)
+		assert.Empty(t, got.Notes, "no matches and no rows needs no explanation")
+	})
+
+	t.Run("partial page still reports as a sample", func(t *testing.T) {
+		got := newProductResponse("target-intel", &client.IndexQueryResult{
+			Data:  []json.RawMessage{json.RawMessage(`{"ip":"203.0.113.1"}`)},
+			Total: 403,
+		})
+
+		assert.Equal(t, 1, got.Returned)
+		assert.Contains(t, strings.Join(got.Notes, " "), "sample")
+	})
+}


### PR DESCRIPTION
Found while smoke-testing the merged product tools against the live API.

## Problem

A `search_target_intel` query for a widely-exposed CVE with a small `limit` returns **zero rows while reporting a non-zero total** — and the response then described those absent rows as a sample.

The empty page comes from upstream: the filter is applied to a page after it has been sliced, so a small `limit` can legitimately yield nothing even when records match. Larger limits return rows normally and the default page size is unaffected, so this is not a regression in the bound or the defaults.

The **reporting** was the bug. "These rows are a sample" is false when there are no rows, and it left two very different situations indistinguishable:

- a query that matched nothing
- a query that matched plenty and returned none of it on this page

For a security tool those must never look alike. The first says "you are not affected"; the second says "ask again". Conflating them is the failure mode #46 fixed for advisory queries, reintroduced in a new place.

## Change

An empty page with a non-zero total now says so and names the recovery — retry with a larger limit. A genuinely empty result stays quiet, because no matches and no rows needs no explanation. A partial page still reports as a sample, unchanged.

## Verification

Reproduced the original response, applied the fix, and confirmed the same query now returns an actionable note instead of a misleading one. Three tests cover the branches: empty-with-matches, genuinely-empty, and partial page.

`make test && make lint` pass.