### PR TITLE
feat(tools): Make index discovery cheap and report per-index filters

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,7 +4,8 @@
 
 | Tool | Description |
 |------|-------------|
-| `list_indices` | List all VulnCheck indices. Call this first to discover which index names can be passed to `search_index`. Accepts an optional `search` parameter to filter by name or description. |
+| `list_indices` | List VulnCheck index names. Returns names only unless a `search` narrows the set, since the full catalogue is large; descriptions can be requested explicitly with `include_description`. |
+| `describe_index` | Report which filters an index accepts, how large it is, and which tool to query it with. Call before `search_index` against an unfamiliar index — indices accept different filters, and one an index does not support has no effect rather than raising an error. |
 | `search_index` | Query a VulnCheck index by name. Supports identifier, threat-intelligence and date-range filters, sorting, and cursor-based pagination. For IP Intelligence, Target Intelligence and Canary Intelligence, prefer the dedicated product tools below. |
 
 ## Products

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -16,6 +16,7 @@ type Client interface {
 	ListBackups(ctx context.Context) ([]Entry, error)
 	ListC2Hostnames(ctx context.Context) (string, error)
 	SearchIndex(ctx context.Context, q SearchIndexQuery) (*IndexQueryResult, error)
+	DescribeIndex(ctx context.Context, index string) (*IndexDescription, error)
 	GetBackup(ctx context.Context, index string) (*GetBackupResult, error)
 	GetCPECVEs(ctx context.Context, cpe string, vulnerableOnly bool) (*CPECVEsResult, error)
 	SearchCPE(ctx context.Context, q SearchCPEQuery) (*SearchCPEResult, error)

--- a/internal/client/describe_index.go
+++ b/internal/client/describe_index.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// IndexDescription reports what an index holds and which filters it accepts.
+type IndexDescription struct {
+	Name string `json:"name"`
+
+	// Filters are the query parameters the index reports as supported. This is the
+	// index's own account of itself, which is more current than any documentation.
+	Filters []string `json:"filters"`
+
+	// TotalDocuments is the size of the index, useful for judging whether a query
+	// against it needs narrowing before it is worth running.
+	TotalDocuments int `json:"total_documents"`
+
+	// DefaultSort is the field the index orders by when none is requested.
+	DefaultSort string `json:"default_sort,omitempty"`
+}
+
+// describeMeta is the subset of the index envelope this needs. Parameters arrive as
+// objects carrying a name and sometimes a format; only the name is of use here.
+type describeMeta struct {
+	Meta struct {
+		TotalDocuments int    `json:"total_documents"`
+		Sort           string `json:"sort"`
+		Parameters     []struct {
+			Name string `json:"name"`
+		} `json:"parameters"`
+	} `json:"_meta"`
+}
+
+// DescribeIndex reports an index's supported filters by making the smallest possible
+// query against it and reading the metadata the response carries.
+//
+// There is no dedicated endpoint for this, and asking for the filters of all indices
+// at once would mean a request each, so this describes one index at a time.
+func (c *VulncheckClient) DescribeIndex(ctx context.Context, index string) (*IndexDescription, error) {
+	if index == "" {
+		return nil, ErrNoIndexArg
+	}
+
+	u, err := url.Parse(c.baseURL + "/v3/index/" + url.PathEscape(index))
+	if err != nil {
+		return nil, fmt.Errorf("building URL: %w", err)
+	}
+	q := u.Query()
+	// One document is enough: the metadata this reads does not depend on the page.
+	q.Set("limit", "1")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.http.Do(req) //nolint:gosec // G704: baseURL is trusted config; index name is path-escaped
+	if err != nil {
+		return nil, fmt.Errorf("describing index %q: %w", index, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("index %q: HTTP %d: %s", index, resp.StatusCode, body)
+	}
+
+	var envelope describeMeta
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	// The parameter list can repeat a name; de-duplicate so the caller sees each
+	// filter once.
+	seen := map[string]bool{}
+	filters := make([]string, 0, len(envelope.Meta.Parameters))
+	for _, p := range envelope.Meta.Parameters {
+		if p.Name == "" || seen[p.Name] {
+			continue
+		}
+		seen[p.Name] = true
+		filters = append(filters, p.Name)
+	}
+
+	return &IndexDescription{
+		Name:           index,
+		Filters:        filters,
+		TotalDocuments: envelope.Meta.TotalDocuments,
+		DefaultSort:    envelope.Meta.Sort,
+	}, nil
+}

--- a/internal/client/describe_index_test.go
+++ b/internal/client/describe_index_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeIndex(t *testing.T) {
+	var got *url.URL
+	c := newAPITestClient(func(r *http.Request) (*http.Response, error) {
+		got = r.URL
+		return jsonResp(http.StatusOK, map[string]any{
+			"_meta": map[string]any{
+				"total_documents": 384273,
+				"sort":            "lastModified",
+				"parameters": []any{
+					// The upstream list repeats a name; the caller should see it once.
+					map[string]any{"name": "date", "format": "YYYY-MM-DD"},
+					map[string]any{"name": "date", "format": "YYYY-MM-DD"},
+					map[string]any{"name": "cve", "format": "CVE-YYYY-N{4-7}"},
+					map[string]any{"name": ""},
+				},
+			},
+			"data": []any{},
+		}), nil
+	})
+
+	desc, err := c.DescribeIndex(context.Background(), "vulncheck-nvd2")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/v3/index/vulncheck-nvd2", got.Path)
+	assert.Equal(t, "1", got.Query().Get("limit"),
+		"one document is enough, since the metadata does not depend on the page")
+	assert.Equal(t, "vulncheck-nvd2", desc.Name)
+	assert.Equal(t, 384273, desc.TotalDocuments)
+	assert.Equal(t, "lastModified", desc.DefaultSort)
+	assert.Equal(t, []string{"date", "cve"}, desc.Filters,
+		"duplicates collapse and blank names are dropped, preserving order")
+}
+
+func TestDescribeIndex_RequiresAnIndex(t *testing.T) {
+	c := newAPITestClient(func(*http.Request) (*http.Response, error) {
+		t.Fatal("no request should be made without an index")
+		return nil, nil
+	})
+	_, err := c.DescribeIndex(context.Background(), "")
+	require.ErrorIs(t, err, ErrNoIndexArg)
+}
+
+func TestDescribeIndex_SurfacesHTTPErrors(t *testing.T) {
+	c := newAPITestClient(func(*http.Request) (*http.Response, error) {
+		return errResp(http.StatusNotFound), nil
+	})
+	_, err := c.DescribeIndex(context.Background(), "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}

--- a/internal/server/describe_index.go
+++ b/internal/server/describe_index.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/vulncheck-oss/mcp/internal/client"
+)
+
+// dedicatedTools maps an index to the tool that wraps it. Where one exists it exposes
+// filters search_index does not, so a caller asking what an index supports should be
+// sent there rather than left to compose the generic tool.
+var dedicatedTools = map[string]string{
+	targetIntelIndex: "search_target_intel",
+	canaryPrefix:     "search_canaries",
+}
+
+func init() {
+	for _, w := range indexWindows {
+		dedicatedTools[ipIntelPrefix+"-"+w] = "search_ip_intel"
+		dedicatedTools[canaryPrefix+"-"+w] = "search_canaries"
+	}
+}
+
+type describeIndexArgs struct {
+	Index string `json:"index" jsonschema:"Index name to describe, e.g. 'vulncheck-nvd2'. Use list_indices to discover names"`
+}
+
+var DescribeIndexTool = &mcp.Tool{
+	Name:  "describe_index",
+	Title: "Describe Index",
+	Description: "Report which filters an index accepts, how large it is, and which tool to use for it. " +
+		"Call this before search_index against an unfamiliar index: indices accept different filters, and one an index does not support has no effect rather than raising an error, so a query can appear to filter when it does not. " +
+		"Filters are read from the index itself, so the list reflects what it currently supports.",
+	Annotations: &mcp.ToolAnnotations{
+		ReadOnlyHint: true,
+	},
+}
+
+type describeIndexResult struct {
+	*client.IndexDescription
+
+	// Tool names the dedicated tool for this index when one exists, so the answer to
+	// "how do I query this" comes back with the answer to "what can I filter on".
+	Tool string `json:"tool,omitempty"`
+
+	// SupportedByTool lists the filters the named tool can send, which is a subset of
+	// what the index advertises.
+	SupportedByTool []string `json:"supported_by_tool,omitempty"`
+
+	Notes []string `json:"notes,omitempty"`
+}
+
+const (
+	dedicatedToolNote = "this index has a dedicated tool, listed in tool, which exposes filters " +
+		"search_index does not — prefer it"
+
+	genericToolNote = "query this index with search_index. It sends the filters common to every " +
+		"index, so a filter listed here that search_index has no argument for cannot be sent"
+)
+
+func registerDescribeIndex(srv *mcp.Server, vc client.Client) {
+	mcp.AddTool(srv, DescribeIndexTool, MakeDescribeIndexHandler(vc))
+}
+
+func MakeDescribeIndexHandler(vc client.Client) mcp.ToolHandlerFor[describeIndexArgs, any] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args describeIndexArgs) (*mcp.CallToolResult, any, error) {
+		description, err := vc.DescribeIndex(ctx, args.Index)
+		if err != nil {
+			return nil, nil, fmt.Errorf("describing index: %w", err)
+		}
+
+		result := describeIndexResult{IndexDescription: description}
+		if tool, ok := dedicatedTools[args.Index]; ok {
+			result.Tool = tool
+			result.Notes = append(result.Notes, dedicatedToolNote)
+		} else {
+			result.Tool = "search_index"
+			result.SupportedByTool = intersect(description.Filters, searchIndexFilters)
+			result.Notes = append(result.Notes, genericToolNote)
+		}
+
+		out, err := json.Marshal(result)
+		if err != nil {
+			return nil, nil, fmt.Errorf("serializing results: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(out)}},
+		}, nil, nil
+	}
+}
+
+// intersect keeps the members of advertised that the tool can actually send,
+// preserving the index's own ordering.
+func intersect(advertised []string, supported map[string]bool) []string {
+	out := make([]string, 0, len(advertised))
+	for _, f := range advertised {
+		if supported[f] {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/internal/server/describe_index_test.go
+++ b/internal/server/describe_index_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulncheck-oss/mcp/internal/client"
+)
+
+func describeMock(desc *client.IndexDescription, err error) *mockClient {
+	return &mockClient{
+		describeIndexFn: func(_ context.Context, index string) (*client.IndexDescription, error) {
+			if err != nil {
+				return nil, err
+			}
+			if desc != nil {
+				return desc, nil
+			}
+			return &client.IndexDescription{Name: index}, nil
+		},
+	}
+}
+
+func decodeDescribe(t *testing.T, res *mcp.CallToolResult) describeIndexResult {
+	t.Helper()
+	require.Len(t, res.Content, 1)
+	text, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var got describeIndexResult
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &got))
+	return got
+}
+
+// Every index with a dedicated tool must name a tool that is actually registered,
+// or describe_index would send callers to something that does not exist.
+func TestDedicatedTools_NameRegisteredTools(t *testing.T) {
+	srv := New(&mockClient{}, "test", nil)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = srv.Run(ctx, serverTransport) }()
+
+	session, err := mcp.NewClient(&mcp.Implementation{Name: "t", Version: "1"}, nil).Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+
+	listed, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+	names := make([]string, 0, len(listed.Tools))
+	for _, tool := range listed.Tools {
+		names = append(names, tool.Name)
+	}
+
+	for index, tool := range dedicatedTools {
+		assert.True(t, slices.Contains(names, tool),
+			"index %q points at tool %q, which is not registered", index, tool)
+	}
+	assert.True(t, slices.Contains(names, "search_index"), "the generic fallback must exist")
+}
+
+func TestDescribeIndex_ReportsFiltersAndSize(t *testing.T) {
+	vc := describeMock(&client.IndexDescription{
+		Name:           "vulncheck-nvd2",
+		Filters:        []string{"cve", "alias", "threat_actor", "kind"},
+		TotalDocuments: 384273,
+		DefaultSort:    "lastModified",
+	}, nil)
+
+	res, _, err := MakeDescribeIndexHandler(vc)(context.Background(), nil, describeIndexArgs{Index: "vulncheck-nvd2"})
+	require.NoError(t, err)
+
+	got := decodeDescribe(t, res)
+	assert.Equal(t, "vulncheck-nvd2", got.Name)
+	assert.Equal(t, 384273, got.TotalDocuments)
+	assert.Equal(t, "lastModified", got.DefaultSort)
+	assert.Equal(t, []string{"cve", "alias", "threat_actor", "kind"}, got.Filters)
+}
+
+// An index without a dedicated tool is served by search_index, which cannot send
+// every filter the index advertises. Reporting the intersection is what stops a
+// caller assuming an advertised filter is reachable.
+func TestDescribeIndex_ReportsWhichFiltersTheGenericToolCanSend(t *testing.T) {
+	vc := describeMock(&client.IndexDescription{
+		Name:    "vulncheck-nvd2",
+		Filters: []string{"cve", "threat_actor", "kind", "matches"},
+	}, nil)
+
+	res, _, err := MakeDescribeIndexHandler(vc)(context.Background(), nil, describeIndexArgs{Index: "vulncheck-nvd2"})
+	require.NoError(t, err)
+
+	got := decodeDescribe(t, res)
+	assert.Equal(t, "search_index", got.Tool)
+	assert.Equal(t, []string{"cve", "threat_actor"}, got.SupportedByTool,
+		"kind and matches are advertised but search_index has no argument for them")
+	assert.Contains(t, strings.Join(got.Notes, " "), "search_index")
+}
+
+func TestDescribeIndex_PointsAtTheDedicatedTool(t *testing.T) {
+	for index, want := range map[string]string{
+		"target-intel":          "search_target_intel",
+		"ipintel-30d":           "search_ip_intel",
+		"vulncheck-canaries":    "search_canaries",
+		"vulncheck-canaries-3d": "search_canaries",
+	} {
+		t.Run(index, func(t *testing.T) {
+			vc := describeMock(&client.IndexDescription{Name: index, Filters: []string{"cve", "asn"}}, nil)
+			res, _, err := MakeDescribeIndexHandler(vc)(context.Background(), nil, describeIndexArgs{Index: index})
+			require.NoError(t, err)
+
+			got := decodeDescribe(t, res)
+			assert.Equal(t, want, got.Tool)
+			assert.Contains(t, strings.Join(got.Notes, " "), "dedicated tool")
+			assert.Empty(t, got.SupportedByTool,
+				"a dedicated tool exposes the index's filters, so the subset is not the interesting fact")
+		})
+	}
+}
+
+func TestDescribeIndex_PropagatesErrors(t *testing.T) {
+	_, _, err := MakeDescribeIndexHandler(describeMock(nil, errors.New("nope")))(
+		context.Background(), nil, describeIndexArgs{Index: "nope"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "describing index")
+}

--- a/internal/server/list_indices.go
+++ b/internal/server/list_indices.go
@@ -11,16 +11,19 @@ import (
 )
 
 var ListIndicesTool = &mcp.Tool{
-	Name:        "list_indices",
-	Title:       "List Indices",
-	Description: "List all VulnCheck indices. Call this first to discover which index names can be passed to search_index. Accepts an optional 'search' parameter to filter results by name or description.",
+	Name:  "list_indices",
+	Title: "List Indices",
+	Description: "List VulnCheck index names. Call this first to discover which index names exist. " +
+		"Returns names only unless a search narrows the set, since the full catalogue is large; descriptions can be requested explicitly. " +
+		"Use describe_index to find out which filters an index accepts and which tool to query it with.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
 }
 
 type listIndicesArgs struct {
-	Search string `json:"search,omitempty" jsonschema:"Optional filter — return only indices whose name or description contains this string (case-insensitive)"`
+	Search             string `json:"search,omitempty"              jsonschema:"Optional filter — return only indices whose name or description contains this string (case-insensitive)"`
+	IncludeDescription *bool  `json:"include_description,omitempty" jsonschema:"Include each index's description. Omitted by default because the full catalogue is large, and included automatically when search narrows it. Set true to force, false to suppress"`
 }
 
 type listEntriesResult struct {
@@ -39,6 +42,14 @@ func MakeListIndicesHandler(vc client.Client) mcp.ToolHandlerFor[listIndicesArgs
 			return nil, nil, fmt.Errorf("listing indices: %w", err)
 		}
 
+		// Descriptions are the bulk of this response. A search narrows the set enough
+		// that they are worth including, so the default follows the caller's intent
+		// rather than making them ask twice.
+		withDescription := args.Search != ""
+		if args.IncludeDescription != nil {
+			withDescription = *args.IncludeDescription
+		}
+
 		if args.Search != "" {
 			q := strings.ToLower(args.Search)
 			filtered := entries[:0]
@@ -48,6 +59,12 @@ func MakeListIndicesHandler(vc client.Client) mcp.ToolHandlerFor[listIndicesArgs
 				}
 			}
 			entries = filtered
+		}
+
+		if !withDescription {
+			for i := range entries {
+				entries[i].Description = ""
+			}
 		}
 
 		out, err := json.Marshal(listEntriesResult{

--- a/internal/server/list_indices_test.go
+++ b/internal/server/list_indices_test.go
@@ -112,3 +112,74 @@ func TestMakeListIndicesHandler(t *testing.T) {
 		})
 	}
 }
+
+// The full catalogue is large and descriptions are the bulk of it, so a bare call
+// returns names only. An agent is told to call this first, so its default cost
+// matters more than its completeness.
+func TestListIndices_OmitsDescriptionsByDefault(t *testing.T) {
+	vc := &mockClient{
+		listIndicesFn: func(_ context.Context) ([]client.Entry, error) {
+			return []client.Entry{
+				{Name: "exploits", Description: "a long description"},
+				{Name: "vulncheck-nvd2", Description: "another long description"},
+			}, nil
+		},
+	}
+
+	res, _, err := MakeListIndicesHandler(vc)(context.Background(), nil, listIndicesArgs{})
+	require.NoError(t, err)
+
+	var got listEntriesResult
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &got))
+	require.Len(t, got.Data, 2)
+	for _, e := range got.Data {
+		assert.NotEmpty(t, e.Name, "names are the point of the call")
+		assert.Empty(t, e.Description)
+	}
+}
+
+// A search narrows the set enough that descriptions are worth having, and asking for
+// them separately would mean two calls to answer one question.
+func TestListIndices_IncludesDescriptionsWhenSearching(t *testing.T) {
+	vc := &mockClient{
+		listIndicesFn: func(_ context.Context) ([]client.Entry, error) {
+			return []client.Entry{
+				{Name: "exploits", Description: "exploit intelligence"},
+				{Name: "vulncheck-nvd2", Description: "vulnerability records"},
+			}, nil
+		},
+	}
+
+	res, _, err := MakeListIndicesHandler(vc)(context.Background(), nil, listIndicesArgs{Search: "exploit"})
+	require.NoError(t, err)
+
+	var got listEntriesResult
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &got))
+	require.Len(t, got.Data, 1)
+	assert.Equal(t, "exploit intelligence", got.Data[0].Description)
+}
+
+func TestListIndices_DescriptionOverrides(t *testing.T) {
+	entries := []client.Entry{{Name: "exploits", Description: "exploit intelligence"}}
+	vc := &mockClient{
+		listIndicesFn: func(_ context.Context) ([]client.Entry, error) { return entries, nil },
+	}
+	on, off := true, false
+
+	t.Run("forced on without a search", func(t *testing.T) {
+		res, _, err := MakeListIndicesHandler(vc)(context.Background(), nil, listIndicesArgs{IncludeDescription: &on})
+		require.NoError(t, err)
+		var got listEntriesResult
+		require.NoError(t, json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &got))
+		assert.Equal(t, "exploit intelligence", got.Data[0].Description)
+	})
+
+	t.Run("forced off despite a search", func(t *testing.T) {
+		res, _, err := MakeListIndicesHandler(vc)(context.Background(), nil,
+			listIndicesArgs{Search: "exploit", IncludeDescription: &off})
+		require.NoError(t, err)
+		var got listEntriesResult
+		require.NoError(t, json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &got))
+		assert.Empty(t, got.Data[0].Description)
+	})
+}

--- a/internal/server/mock_test.go
+++ b/internal/server/mock_test.go
@@ -12,6 +12,7 @@ type mockClient struct {
 	listBackupsFn         func(ctx context.Context) ([]client.Entry, error)
 	getBackupFn           func(ctx context.Context, index string) (*client.GetBackupResult, error)
 	searchIndexFn         func(ctx context.Context, q client.SearchIndexQuery) (*client.IndexQueryResult, error)
+	describeIndexFn       func(ctx context.Context, index string) (*client.IndexDescription, error)
 	getCPECVEsFn          func(ctx context.Context, cpe string, vulnerableOnly bool) (*client.CPECVEsResult, error)
 	searchCPEFn           func(ctx context.Context, q client.SearchCPEQuery) (*client.SearchCPEResult, error)
 	searchPURLsFn         func(ctx context.Context, purls []string) (*client.SearchPURLsResult, error)
@@ -42,6 +43,10 @@ func (m *mockClient) GetBackup(ctx context.Context, index string) (*client.GetBa
 
 func (m *mockClient) SearchIndex(ctx context.Context, q client.SearchIndexQuery) (*client.IndexQueryResult, error) {
 	return m.searchIndexFn(ctx, q)
+}
+
+func (m *mockClient) DescribeIndex(ctx context.Context, index string) (*client.IndexDescription, error) {
+	return m.describeIndexFn(ctx, index)
 }
 
 func (m *mockClient) GetCPECVEs(ctx context.Context, cpe string, vulnerableOnly bool) (*client.CPECVEsResult, error) {

--- a/internal/server/search_index.go
+++ b/internal/server/search_index.go
@@ -34,6 +34,19 @@ type searchIndexArgs struct {
 	Cursor             string `json:"cursor,omitempty"                jsonschema:"Cursor token from a previous next_cursor to fetch the next page"`
 }
 
+// searchIndexFilters are the upstream query keys this tool can send. describe_index
+// intersects an index's advertised filters with this set, so a caller can see which of
+// them are reachable here rather than assuming all of them are.
+var searchIndexFilters = map[string]bool{
+	"cve": true, "alias": true, "iava": true, "jvndb": true,
+	"threat_actor": true, "mitre_id": true, "misp_id": true,
+	"ransomware": true, "botnet": true,
+	"lastModStartDate": true, "lastModEndDate": true,
+	"pubStartDate": true, "pubEndDate": true,
+	"updatedAtStartDate": true, "updatedAtEndDate": true,
+	"date": true, "sort": true, "order": true,
+}
+
 var SearchIndexTool = &mcp.Tool{
 	Name:  "search_index",
 	Title: "Search Index",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 var tools = []func(*mcp.Server, client.Client){
 	// v3/index
 	registerListIndices,
+	registerDescribeIndex,
 	registerSearchIndex,
 	// v3/index — flagship product wrappers
 	registerSearchTargetIntel,


### PR DESCRIPTION
Base `main`, independent of #55 and #56.

## Two problems with finding your way to an index

**The catalogue is expensive to list, and the server tells you to list it first.** Descriptions are most of its weight, so that cost is paid before any real work happens.

**Knowing an index exists does not tell you how to query it.** Indices accept different filters, and a filter an index does not support has *no effect* rather than raising an error — so a query can appear to filter when it does not. There was no way to find out which filters applied short of reading documentation that does not always match the API.

The second is the more serious one, and it is the root cause behind the filter gaps closed in #51 and #52: the information needed to compose a correct query was not reachable from the tools.

## Changes

**`list_indices` returns names only by default**, which cuts the response by roughly two thirds. Descriptions come back automatically when a `search` narrows the set — at that point they are worth having, and asking separately would mean two calls to answer one question. `include_description` forces either way.

**`describe_index` is new.** It reports, for one index: the filters it accepts, how large it is, and what it sorts by. There is no endpoint for this, so it reads the metadata on the smallest possible query. The upstream parameter list can repeat a name, so it is de-duplicated.

It also answers the question that immediately follows. Where an index has a dedicated tool it names it, because that tool exposes filters the generic one cannot. Otherwise it names `search_index` **and reports which of the advertised filters `search_index` can actually send** — the intersection, not the whole list. Reporting everything the index accepts would imply all of it is reachable, which is the assumption this is meant to correct.

## Notes for review

- A test asserts every index-to-tool mapping names a **registered** tool, so the mapping cannot come to point at something that does not exist.
- The exploit index is deliberately absent from that mapping: its dedicated tool is on the branch in #56. Adding the entry is a one-line follow-up once that merges, and the test above would not catch its absence — flagging it rather than relying on memory.
- `describe_index` reports what the index advertises. That is the best available account and more current than documentation, but it is an advertisement rather than a guarantee, which is why the response separates "advertised by the index" from "sendable by the tool".
- Verified live: the default listing is materially smaller than the full one, a narrow search returns descriptions, and `describe_index` correctly routes a generic index to `search_index` with a reduced filter set and a windowed index to its dedicated tool.

`make test && make lint` pass.
