### PR TITLE
feat(tools): Make search_docs actually search

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -30,7 +30,7 @@ Your MCP client lists the available arguments for each tool; the summaries below
 
 | Tool | Description |
 |------|-------------|
-| `search_docs` | Fetch the VulnCheck documentation index. Returns a list of all available documentation pages and their URLs. Use `get_doc` to retrieve the content of a specific page. |
+| `search_docs` | Search the VulnCheck documentation and return matching pages ranked by relevance, with titles, descriptions and URLs. Pass a URL to `get_doc` for the page itself. Searches every section except translations of the primary content; call without a query to list the sections. |
 | `get_doc` | Fetch the raw markdown content of a VulnCheck documentation page. Use `search_docs` first to discover available page URLs. |
 
 ## CVE Search

--- a/internal/server/docs_index.go
+++ b/internal/server/docs_index.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// The documentation index is published as a flat list of pages, one per line, in the
+// form "- [Title](url): description", grouped under headings that separate the
+// English pages from their translations and from the changelog.
+//
+// There is no search endpoint for it, so searching means parsing that list and
+// scoring it here. The alternative — returning the whole index and leaving the caller
+// to read it — costs a large share of a context window to answer one question.
+var (
+	docsHeading = regexp.MustCompile(`^#{1,6}\s+(.+?)\s*$`)
+	docsEntry   = regexp.MustCompile(`^-\s+\[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?$`)
+)
+
+// Some sections are translations of the English pages rather than distinct content,
+// so by default they are left out: including them returns each result several times
+// over in languages the caller did not ask for. Other sections carry their own
+// English content and must not be excluded — narrowing to the primary section alone
+// would hide the changelog and the weekly intelligence reports entirely.
+//
+// A section is taken to be a translation when its name is a two-letter language code
+// and its pages live under a matching path segment. Both conditions are needed: the
+// path test alone would catch any section published under its own name, such as the
+// changelog, and the name test alone would catch the primary section. Detecting it
+// this way means a language added later is excluded without a code change.
+func isTranslationSection(section string, pages []DocPage) bool {
+	if !isLanguageCode(section) {
+		return false
+	}
+	prefix := "/raw/" + strings.ToLower(section) + "/"
+	seen, under := 0, 0
+	for _, p := range pages {
+		if p.Section != section {
+			continue
+		}
+		seen++
+		if strings.Contains(strings.ToLower(p.URL), prefix) {
+			under++
+		}
+	}
+	return seen > 0 && under*2 > seen
+}
+
+// isLanguageCode reports whether a section name looks like a two-letter language code.
+func isLanguageCode(section string) bool {
+	if len(section) != 2 {
+		return false
+	}
+	for _, r := range strings.ToLower(section) {
+		if r < 'a' || r > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// translationSections reports which sections are translations of the primary content.
+func translationSections(pages []DocPage) map[string]bool {
+	out := map[string]bool{}
+	for _, sc := range docsSectionCounts(pages) {
+		if isTranslationSection(sc.Section, pages) {
+			out[sc.Section] = true
+		}
+	}
+	return out
+}
+
+// maxDocsResults bounds a search response. Ten pages is more than enough to choose
+// from, and the count of matches is reported separately so a caller can tell when it
+// should narrow instead of paginate.
+const maxDocsResults = 10
+
+// DocPage is one page in the documentation index.
+type DocPage struct {
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Description string `json:"description,omitempty"`
+	Section     string `json:"section,omitempty"`
+}
+
+// parseDocsIndex reads the published index into pages, tagging each with the heading
+// it appeared under. Lines that are neither a heading nor an entry are skipped, so a
+// change to the surrounding prose does not break parsing.
+func parseDocsIndex(raw string) []DocPage {
+	var pages []DocPage
+	section := ""
+
+	for line := range strings.SplitSeq(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if m := docsHeading.FindStringSubmatch(trimmed); m != nil {
+			// The document title is a single-hash heading above any section, so it is
+			// only treated as a section when it is nested.
+			if strings.HasPrefix(trimmed, "##") {
+				section = m[1]
+			}
+			continue
+		}
+		if m := docsEntry.FindStringSubmatch(trimmed); m != nil {
+			pages = append(pages, DocPage{
+				Title:       strings.TrimSpace(m[1]),
+				URL:         strings.TrimSpace(m[2]),
+				Description: strings.TrimSpace(m[3]),
+				Section:     section,
+			})
+		}
+	}
+	return pages
+}
+
+// docsSectionCounts reports how many pages each section holds, in the order the
+// sections appear, so a caller with no query can see what exists before searching.
+//
+// It does not mark translations, because the check for those calls this — see
+// annotateTranslations for the caller-facing version.
+func docsSectionCounts(pages []DocPage) []SectionCount {
+	var order []string
+	counts := map[string]int{}
+	for _, p := range pages {
+		if _, seen := counts[p.Section]; !seen {
+			order = append(order, p.Section)
+		}
+		counts[p.Section]++
+	}
+	out := make([]SectionCount, 0, len(order))
+	for _, s := range order {
+		out = append(out, SectionCount{Section: s, Pages: counts[s]})
+	}
+	return out
+}
+
+// SectionCount is one section of the documentation and its size.
+type SectionCount struct {
+	Section string `json:"section"`
+	Pages   int    `json:"pages"`
+
+	// Translation marks a section that restates the primary content in another
+	// language. Those are excluded from a search unless named explicitly, so saying
+	// which they are explains an otherwise surprising omission.
+	Translation bool `json:"translation,omitempty"`
+}
+
+// annotateTranslations returns the section counts with translations marked.
+func annotateTranslations(pages []DocPage) []SectionCount {
+	counts := docsSectionCounts(pages)
+	for i := range counts {
+		counts[i].Translation = isTranslationSection(counts[i].Section, pages)
+	}
+	return counts
+}
+
+// scoredPage carries a page with its relevance, kept separate so the score does not
+// reach the caller — it is an implementation detail of the ranking, not information
+// a caller can act on.
+type scoredPage struct {
+	page    DocPage
+	score   int
+	matched int
+}
+
+// searchDocsIndex ranks pages against the query terms.
+//
+// Titles are weighted above descriptions because a page whose title carries the term
+// is usually about it, whereas a description may only mention it in passing. Pages
+// matching every term rank above pages matching some, so an unusually specific query
+// does not get swamped by entries that happen to repeat one common word.
+// An empty section searches every section that is not a translation. Naming a section
+// searches only that one, including a translation if that is what was asked for.
+func searchDocsIndex(pages []DocPage, query, section string) ([]DocPage, int) {
+	terms := docsQueryTerms(query)
+	if len(terms) == 0 {
+		return nil, 0
+	}
+
+	translations := map[string]bool{}
+	if section == "" {
+		translations = translationSections(pages)
+	}
+
+	var scored []scoredPage
+	for _, p := range pages {
+		if section != "" && !strings.EqualFold(p.Section, section) {
+			continue
+		}
+		if translations[p.Section] {
+			continue
+		}
+		title := strings.ToLower(p.Title)
+		desc := strings.ToLower(p.Description)
+		urlPath := strings.ToLower(p.URL)
+
+		score, matched := 0, 0
+		for _, t := range terms {
+			hit := false
+			if strings.Contains(title, t) {
+				score += 10
+				hit = true
+			}
+			if strings.Contains(desc, t) {
+				score += 3
+				hit = true
+			}
+			// The URL carries the page's path, which names the product or endpoint even
+			// when the title is generic, such as a page called "Overview".
+			if strings.Contains(urlPath, t) {
+				score += 2
+				hit = true
+			}
+			if hit {
+				matched++
+			}
+		}
+		if matched > 0 {
+			scored = append(scored, scoredPage{page: p, score: score, matched: matched})
+		}
+	}
+
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].matched != scored[j].matched {
+			return scored[i].matched > scored[j].matched
+		}
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
+		}
+		return scored[i].page.Title < scored[j].page.Title
+	})
+
+	total := len(scored)
+	if len(scored) > maxDocsResults {
+		scored = scored[:maxDocsResults]
+	}
+	out := make([]DocPage, 0, len(scored))
+	for _, s := range scored {
+		out = append(out, s.page)
+	}
+	return out, total
+}
+
+// docsStopWords are terms too common in a documentation question to discriminate
+// between pages. Left in, a question phrased as a sentence scores every page that
+// happens to contain "the".
+var docsStopWords = map[string]bool{
+	"a": true, "an": true, "and": true, "are": true, "as": true, "at": true,
+	"be": true, "by": true, "can": true, "do": true, "does": true, "for": true,
+	"from": true, "how": true, "i": true, "in": true, "is": true, "it": true,
+	"me": true, "my": true, "of": true, "on": true, "or": true, "the": true,
+	"to": true, "what": true, "when": true, "where": true, "which": true,
+	"with": true, "you": true,
+}
+
+// docsQueryTerms splits a query into comparable terms, dropping punctuation and words
+// too common to narrow anything. A query made entirely of stop words keeps them,
+// since returning nothing would be less useful than returning a weak match.
+func docsQueryTerms(query string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
+		letter := 'a' <= r && r <= 'z'
+		digit := '0' <= r && r <= '9'
+		return !letter && !digit && r != '-' && r != '_'
+	})
+
+	terms := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if len(f) < 2 || docsStopWords[f] {
+			continue
+		}
+		terms = append(terms, f)
+	}
+	if len(terms) == 0 {
+		return fields
+	}
+	return terms
+}

--- a/internal/server/search_docs.go
+++ b/internal/server/search_docs.go
@@ -2,33 +2,92 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/vulncheck-oss/mcp/internal/client"
 )
 
+type searchDocsArgs struct {
+	Query   string `json:"query,omitempty"   jsonschema:"What to look for, e.g. 'filter canaries by country' or 'api tokens'. Matched against page titles, descriptions and paths. Omit to list the available documentation sections instead"`
+	Section string `json:"section,omitempty" jsonschema:"Restrict the search to one documentation section. By default every section is searched except translations of the primary content, which would otherwise return each result once per language. Call without a query to see the sections"`
+}
+
 var SearchDocsTool = &mcp.Tool{
-	Name:        "search_docs",
-	Title:       "Search Docs",
-	Description: "Fetch the VulnCheck documentation index. Returns a list of all available documentation pages and their URLs. Use get_doc to retrieve the content of a specific page.",
+	Name:  "search_docs",
+	Title: "Search Docs",
+	Description: "Search the VulnCheck documentation and return the pages that match, ranked by relevance. " +
+		"Returns titles, descriptions and URLs — pass a URL to get_doc for the page itself. " +
+		"Searches all sections by default, except translations of the primary content. Call without a query to list the sections.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
 }
 
+type searchDocsResult struct {
+	Query    string         `json:"query,omitempty"`
+	Section  string         `json:"section,omitempty"`
+	Data     []DocPage      `json:"data,omitempty"`
+	Returned int            `json:"returned"`
+	Matched  int            `json:"matched"`
+	Sections []SectionCount `json:"sections,omitempty"`
+	Notes    []string       `json:"notes,omitempty"`
+}
+
+const (
+	docsBrowseNote = "no query was given, so this lists the documentation sections rather than every " +
+		"page in them. Search within one by passing a query"
+
+	docsTruncatedNote = "more pages matched than are shown, ranked by relevance — narrow the query " +
+		"rather than asking again, since there is no pagination here"
+
+	docsNoMatchNote = "nothing matched. Try fewer or more general terms, or call without a query to " +
+		"see which sections exist"
+)
+
 func registerSearchDocs(srv *mcp.Server, vc client.Client) {
 	mcp.AddTool(srv, SearchDocsTool, MakeSearchDocsHandler(vc))
 }
 
-func MakeSearchDocsHandler(vc client.Client) mcp.ToolHandlerFor[struct{}, any] {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
-		result, err := vc.SearchDocs(ctx)
+func MakeSearchDocsHandler(vc client.Client) mcp.ToolHandlerFor[searchDocsArgs, any] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args searchDocsArgs) (*mcp.CallToolResult, any, error) {
+		raw, err := vc.SearchDocs(ctx)
 		if err != nil {
-			return nil, nil, fmt.Errorf("searching docs: %w", err)
+			return nil, nil, fmt.Errorf("fetching docs index: %w", err)
 		}
+
+		pages := parseDocsIndex(raw)
+		result := searchDocsResult{Query: args.Query}
+
+		if args.Query == "" {
+			// Returning every page here would cost a large share of the caller's context
+			// to answer a question it has not asked yet.
+			result.Sections = annotateTranslations(pages)
+			result.Notes = append(result.Notes, docsBrowseNote)
+		} else {
+			result.Section = args.Section
+
+			matches, total := searchDocsIndex(pages, args.Query, args.Section)
+			result.Data = matches
+			result.Returned = len(matches)
+			result.Matched = total
+
+			switch {
+			case total == 0:
+				result.Notes = append(result.Notes, docsNoMatchNote)
+			case total > len(matches):
+				result.Notes = append(result.Notes, docsTruncatedNote)
+			}
+		}
+
+		out, err := json.Marshal(result)
+		if err != nil {
+			return nil, nil, fmt.Errorf("serializing results: %w", err)
+		}
+
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: result}},
+			Content: []mcp.Content{&mcp.TextContent{Text: string(out)}},
 		}, nil, nil
 	}
 }

--- a/internal/server/search_docs_test.go
+++ b/internal/server/search_docs_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -10,28 +12,243 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMakeSearchDocsHandler(t *testing.T) {
-	t.Run("returns index content", func(t *testing.T) {
-		const content = "# VulnCheck Docs\nhttps://docs.vulncheck.com/raw/getting-started.md\n"
-		mock := &mockClient{
-			searchDocsFn: func(_ context.Context) (string, error) {
-				return content, nil
-			},
+// docsFixture mirrors the shape of the published index: a title, sections that
+// separate the English pages from their translations, and entries some of which carry
+// no description.
+const docsFixture = `# VulnCheck Docs
+
+> Documentation for the VulnCheck API and more
+
+## En
+
+- [API Tokens](https://docs.vulncheck.com/raw/getting-started/api-tokens.md): All VulnCheck platform API calls require a valid API token.
+- [Canary Intelligence](https://docs.vulncheck.com/raw/products/canary-intelligence.md): Exploitation data from globally deployed vulnerable hosts.
+- [Query Parameters](https://docs.vulncheck.com/raw/products/canary-intelligence/query-parameters.md): Filtering canary data by CVE, country, date and IP.
+- [Overview](https://docs.vulncheck.com/raw/products/target-intelligence.md)
+- [Unrelated Page](https://docs.vulncheck.com/raw/misc/unrelated.md): Nothing to do with the above.
+
+## Jp
+
+- [APIトークン](https://docs.vulncheck.com/raw/jp/getting-started/api-tokens.md): API token page, translated.
+
+## Kr
+
+- [API 토큰](https://docs.vulncheck.com/raw/kr/getting-started/api-tokens.md): API token page, translated again.
+
+## Changelog
+
+- [2026-08-12](https://docs.vulncheck.com/raw/changelog/2026-08-12.md): Recent changes to the canary feed.
+`
+
+func docsMock(content string, err error) *mockClient {
+	return &mockClient{
+		searchDocsFn: func(_ context.Context) (string, error) {
+			if err != nil {
+				return "", err
+			}
+			return content, nil
+		},
+	}
+}
+
+func decodeDocs(t *testing.T, res *mcp.CallToolResult) searchDocsResult {
+	t.Helper()
+	require.Len(t, res.Content, 1)
+	text, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var got searchDocsResult
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &got))
+	return got
+}
+
+func TestParseDocsIndex(t *testing.T) {
+	pages := parseDocsIndex(docsFixture)
+
+	require.Len(t, pages, 8)
+	assert.Equal(t, "API Tokens", pages[0].Title)
+	assert.Equal(t, "https://docs.vulncheck.com/raw/getting-started/api-tokens.md", pages[0].URL)
+	assert.Equal(t, "En", pages[0].Section)
+
+	t.Run("an entry with no description still parses", func(t *testing.T) {
+		var overview DocPage
+		for _, p := range pages {
+			if p.Title == "Overview" {
+				overview = p
+			}
 		}
-		handler := MakeSearchDocsHandler(mock)
-		result, _, err := handler(context.Background(), nil, struct{}{})
-		require.NoError(t, err)
-		assert.Equal(t, content, result.Content[0].(*mcp.TextContent).Text)
+		assert.Equal(t, "En", overview.Section)
+		assert.Empty(t, overview.Description)
+		assert.NotEmpty(t, overview.URL)
 	})
 
-	t.Run("client error propagates", func(t *testing.T) {
-		mock := &mockClient{
-			searchDocsFn: func(_ context.Context) (string, error) {
-				return "", errors.New("connection refused")
-			},
+	t.Run("the document title is not treated as a section", func(t *testing.T) {
+		for _, p := range pages {
+			assert.NotEqual(t, "VulnCheck Docs", p.Section)
 		}
-		handler := MakeSearchDocsHandler(mock)
-		_, _, err := handler(context.Background(), nil, struct{}{})
-		require.Error(t, err)
 	})
+
+	t.Run("later sections are tagged", func(t *testing.T) {
+		var sections []string
+		for _, p := range pages {
+			sections = append(sections, p.Section)
+		}
+		assert.Contains(t, sections, "Jp")
+		assert.Contains(t, sections, "Changelog")
+	})
+}
+
+// Translations restate the primary content, so including them by default would return
+// the same page once per language.
+func TestSearchDocs_ExcludesTranslationsByDefault(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{Query: "api tokens"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	require.NotEmpty(t, got.Data)
+	assert.Equal(t, "API Tokens", got.Data[0].Title)
+	for _, p := range got.Data {
+		assert.NotContains(t, []string{"Jp", "Kr"}, p.Section,
+			"a translated copy of the same page is not a second result")
+	}
+}
+
+// Sections other than the primary one are not all translations. Restricting the search
+// to the primary section would hide the changelog and the weekly reports, which are
+// distinct English content.
+func TestSearchDocs_SearchesEnglishSectionsBeyondThePrimaryOne(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{Query: "canary"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	var sections []string
+	for _, p := range got.Data {
+		sections = append(sections, p.Section)
+	}
+	assert.Contains(t, sections, "Changelog",
+		"the changelog is its own section but is not a translation")
+}
+
+func TestIsTranslationSection(t *testing.T) {
+	pages := parseDocsIndex(docsFixture)
+
+	assert.True(t, isTranslationSection("Jp", pages), "pages sit under a matching path segment")
+	assert.True(t, isTranslationSection("Kr", pages))
+	assert.False(t, isTranslationSection("En", pages), "the primary section has no language segment")
+	assert.False(t, isTranslationSection("Changelog", pages),
+		"published under its own path segment, but not a language code")
+	assert.False(t, isTranslationSection("", pages))
+	assert.False(t, isTranslationSection("Nonexistent", pages))
+}
+
+func TestSearchDocs_OtherSectionsAreReachable(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{Query: "api token", Section: "Jp"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	require.NotEmpty(t, got.Data)
+	assert.Equal(t, "Jp", got.Data[0].Section)
+}
+
+// A title match is a stronger signal than a passing mention in a description.
+func TestSearchDocs_RanksTitleMatchesFirst(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{Query: "canary"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	require.GreaterOrEqual(t, len(got.Data), 2)
+	assert.Equal(t, "Canary Intelligence", got.Data[0].Title,
+		"the page whose title carries the term ranks above one that only mentions it")
+}
+
+// A specific query should not be beaten by a page that repeats one of its common words.
+func TestSearchDocs_PrefersPagesMatchingEveryTerm(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{Query: "canary query parameters"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	require.NotEmpty(t, got.Data)
+	assert.Equal(t, "Query Parameters", got.Data[0].Title)
+}
+
+// The path names the product even where the title is generic, such as "Overview".
+func TestSearchDocs_MatchesOnThePagePath(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{Query: "target-intelligence"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	require.NotEmpty(t, got.Data)
+	assert.Equal(t, "Overview", got.Data[0].Title)
+}
+
+func TestSearchDocs_NoQueryListsSections(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	assert.Empty(t, got.Data, "listing every page is what this change exists to avoid")
+	assert.Equal(t, []SectionCount{
+		{Section: "En", Pages: 5},
+		{Section: "Jp", Pages: 1, Translation: true},
+		{Section: "Kr", Pages: 1, Translation: true},
+		{Section: "Changelog", Pages: 1},
+	}, got.Sections,
+		"sections are reported in order with their sizes, and translations are marked so their "+
+			"exclusion from a default search is explicable")
+	assert.Contains(t, strings.Join(got.Notes, " "), "no query")
+}
+
+func TestSearchDocs_ReportsNoMatchExplicitly(t *testing.T) {
+	res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+		context.Background(), nil, searchDocsArgs{Query: "kubernetes helm chart"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	assert.Empty(t, got.Data)
+	assert.Zero(t, got.Matched)
+	assert.Contains(t, strings.Join(got.Notes, " "), "nothing matched")
+}
+
+func TestSearchDocs_ReportsWhenMoreMatchedThanShown(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("## En\n")
+	for i := range maxDocsResults + 5 {
+		b.WriteString("- [Canary Page ")
+		b.WriteByte(byte('a' + i))
+		b.WriteString("](https://docs.vulncheck.com/raw/p")
+		b.WriteByte(byte('a' + i))
+		b.WriteString(".md): canary detail\n")
+	}
+
+	res, _, err := MakeSearchDocsHandler(docsMock(b.String(), nil))(
+		context.Background(), nil, searchDocsArgs{Query: "canary"})
+	require.NoError(t, err)
+
+	got := decodeDocs(t, res)
+	assert.Len(t, got.Data, maxDocsResults)
+	assert.Equal(t, maxDocsResults, got.Returned)
+	assert.Equal(t, maxDocsResults+5, got.Matched, "the caller is told how much it did not see")
+	assert.Contains(t, strings.Join(got.Notes, " "), "narrow the query")
+}
+
+func TestDocsQueryTerms_DropsWordsThatCannotNarrow(t *testing.T) {
+	assert.Equal(t, []string{"filter", "canaries", "country"},
+		docsQueryTerms("How do I filter canaries by country?"))
+
+	t.Run("a query of only common words keeps them rather than matching nothing", func(t *testing.T) {
+		assert.Equal(t, []string{"how", "do", "i"}, docsQueryTerms("how do i"))
+	})
+}
+
+func TestSearchDocs_PropagatesClientErrors(t *testing.T) {
+	_, _, err := MakeSearchDocsHandler(docsMock("", errors.New("connection refused")))(
+		context.Background(), nil, searchDocsArgs{Query: "anything"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docs index")
 }


### PR DESCRIPTION
Base `main`, independent of the other open PRs.

## Problem

`search_docs` did not search. It fetched the published documentation index and returned all of it — a large share of a context window spent to answer one question, followed by a second call to read the page actually wanted.

There is no search endpoint for the documentation (no `llms-full.txt`, and the plausible search paths all 404), so searching has to happen here.

## Change

The index turns out to be well suited to it: every page is listed as a title, URL and description under section headings, and all of it parses cleanly. So parse it, score against the query, return the matches.

**Scoring.** Titles weighted above descriptions, because a page whose title carries a term is usually about it while a description may only mention it in passing. The URL path is weighted lightly too, since it names the product even where the title is generic — several pages are called "Overview". Pages matching *every* term rank above pages matching some, so a specific query is not swamped by entries repeating one common word. Words too common to discriminate are dropped, unless the query consists only of those, where a weak match beats no answer.

**Bounded and honest.** Ten results, with the number that matched reported separately so a caller can tell when to narrow rather than assume it has seen everything. There is no pagination, and the note says so.

**No query lists the sections and their sizes** rather than every page — enough to orient without answering a question that has not been asked.

## Translations, and a correction

Translations are excluded by default: they restate the primary content, so including them returns each result once per language.

My first attempt restricted the search to the primary section, which was wrong. Other sections carry their own content — the changelog and the weekly intelligence reports are separate sections and around 150 pages between them, and that approach hid all of them from every search. Caught it when the section listing showed their sizes.

So a section is treated as a translation when **its name is a two-letter language code and its pages sit under a matching path segment**. Both conditions are needed: the path test alone catches any section published under its own name, which is how the changelog is published, and the name test alone catches the primary section. A language added later is excluded without a code change.

The section listing marks which sections are translations, so their absence from a default search is explicable rather than surprising.

## Known limitation

The scorer is lexical, and it favours completeness of match over authority of source. A query like "weaponized exploits" surfaces dated changelog entries containing both terms above the product page that is really about it, because that page's title carries only one of them.

That is the ranking rule working as designed rather than a bug, and it is still far better than returning everything. Weighting reference pages above chronological archives would improve it, but that needs a way to tell those apart that is not another name-shaped heuristic — I would rather add it deliberately than guess now.

## Note on scope

`get_doc` is unchanged. My earlier assessment suggested section-level retrieval within pages, but the index only lists pages, so that would mean fetching and splitting page bodies. Pages are a reasonable unit for one answer; the cost was in the index dump, not in reading a page.

Verified against the live documentation site across several queries, both defaults and an explicitly named translation section. `make test && make lint` pass.

Incidentally this settles one of the renames proposed elsewhere: the tool is no longer misnamed.
