### PR TITLE
3312 uniform response envelope

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,5 +1,84 @@
 # Available Tools
 
+## Response envelope
+
+Every list-returning tool reports the same core alongside its rows, so reading an answer does
+not depend on knowing which tool produced it:
+
+| Field | Meaning |
+|---|---|
+| `data` | the rows — **always present**, including when empty |
+| `returned` | how many rows this response carries — **always present**, including `0` |
+| `total` | how many rows matched upstream; unchanged when rows are withheld for size |
+| `next_cursor` | the cursor for the next page; absent when there is no next page |
+| `notes` | what the API did to the query — see below |
+
+`data` and `returned` are never omitted. An empty result is visibly empty rather than
+missing, because "nothing matched" and "something went wrong" must not look the same.
+
+`total > returned` means the rows in front of you are not the whole answer — `total` is. It
+does **not** always mean a next page is reachable: `search_cpe` has no `page`, `limit` or
+`cursor` argument, so its extra rows cannot be fetched through this server at all, and it
+says so in `notes`. Check `notes` and `next_cursor` for the route rather than assuming one.
+
+`search_docs` carries the core too, though it searches a locally-parsed documentation index
+rather than API records, so it bounds itself and stays outside the byte budget below.
+
+**Not yet covered:** the catalogue tools — `list_indices`, `list_backups`,
+`v4_list_advisories`, `v4_list_advisory_backups` — return `{data, total}` with no `returned`
+or `notes`, and are not size-bounded. `list_backups` is the one to know about: it returns all
+516 backups with descriptions, about 62 KB, with no way to ask for names only. Tracked
+separately from the envelope work.
+
+Tools add fields of their own where they have something only they can report — `index` names
+the index a product tool chose on your behalf, `vendors_tried` records the capitalisations
+`v4_search_advisory` retried, `window` and `providers` describe a digest. These are additive;
+the core above is always there.
+
+### Notes
+
+`notes` explains what the **API** did to a query. (What this server did to the response is
+reported separately in `response_size`, below.) The ones to act on:
+
+| Note begins | Meaning |
+|---|---|
+| `FILTERS NOT APPLIED` | **the answer is wrong, not merely partial** — always listed first. An index accepts only some filters, and the API ignores one it does not support instead of rejecting it, returning HTTP 200, unfiltered rows and a plausible-looking `total`. The named filter did nothing. Do not report these rows as narrowed by it. |
+| `records match this query but none was returned` | an empty page with a non-zero `total`: the API filters a page *after* slicing it, so a small `limit` can yield nothing. Not an absence of data. The note ends with the remedy — **retry with a larger limit** normally, or **pass `next_cursor` back as `cursor`** when the response carries one, since enlarging the limit does not advance a walk. |
+| `the cursor walk is complete` | the other reason a page is empty: you have paged to the end. `total` counts what matched upstream, not what remains, so a larger `limit` will not produce more. |
+| `this tool cannot reach the rest` | `search_cpe` only: there is no `page`, `limit` or `cursor` argument, so the rows beyond the first 100 are unreachable here. Use `get_cpe_cves` with a wildcard CPE, or a backup. |
+| `to reach the rest, set start_cursor` | the tool pages by cursor but only issues one when asked. |
+| `these rows are one page of a larger match set` | report `total`, not the row count. |
+| `this index describes a population of hosts or events` | the rows are a sample of a population rather than an enumeration. |
+| `total exceeds what a single sequence of pages can reach` | 10,000 records upstream. **Cursor pagination is not subject to it** — pass `start_cursor`, then feed `next_cursor` back as `cursor`. Use a backup of the index only if you want the whole set at once. |
+
+#### Where filter-drop detection applies
+
+Drops are detected by comparing the filters sent against the parameter list the index
+publishes with every response, so it costs no extra request. That list only exists on
+`/v3/index`, so detection covers exactly five tools: **`search_index`,
+`search_target_intel`, `search_ip_intel`, `search_canaries`, `search_curated_exploits`**.
+
+**On every other tool, the absence of a `FILTERS NOT APPLIED` note is not evidence that your
+filters were applied.** `search_cve`, `search_cpe`, `search_purls`, `get_cpe_cves`,
+`identify_component`, `v4_search_advisory` and `list_recent_advisories` sit on endpoints that
+publish no parameter list, and they cannot be checked. Their upstream endpoints fail in two
+different ways, and the second is the more dangerous:
+
+- `/v3/search/cve`, `/v3/search/cpe`, `/v3/cpe` **ignore** an unrecognised parameter and
+  return HTTP 200 with the *unfiltered* set — so a result can be broader than you asked for.
+- `/v4/advisory` returns **nothing**: an unrecognised parameter yields `total: 0` with a
+  response byte-identical to a genuine no-match. A typo'd filter and "no advisories match"
+  are indistinguishable, and the failure points at *"nothing found"* — the answer you should
+  be least willing to pass on unchecked.
+
+Two further limits on the five tools that *are* checked. A zero-row response carries no
+parameter list, so it is not checked — safely, because an ignored filter can only widen a
+result, so an empty answer cannot be hiding a narrower one. And a filter an index lists but
+does not honour is invisible from outside.
+
+Call `describe_index` before querying an unfamiliar index — it reports the filters that index
+accepts and the values each one takes. For the tools above it is the only check available.
+
 ## Response size
 
 Every tool that returns API records keeps its response within a byte budget — 30,000 bytes
@@ -21,7 +100,8 @@ cut to a single item, so no count visible in it should be reported as real.
 
 When a response is shortened it carries a `response_size` field alongside `data` — every
 tool returns a JSON object, so the report always travels with the records it describes and
-cannot be read apart from them. It reports:
+cannot be read apart from them. It describes what **this server** did to fit the response,
+where [`notes`](#notes) describes what the API did to the query. It reports:
 
 | Field | Meaning |
 |---|---|
@@ -86,8 +166,8 @@ Your MCP client lists the available arguments for each tool; the summaries below
 
 | Tool | Description |
 |------|-------------|
-| `get_cpe_cves` | Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. Any attribute accepts `*` and `?` wildcards, so a trailing wildcard on the product covers every product sharing that prefix in one call — prefer this over `search_cpe` when exploring a vendor, because `search_cpe` returns every matching CPE and its response can reach tens of megabytes. Wildcarding both vendor and product is unbounded and should be avoided. |
-| `search_cpe` | Search for CPEs by component fields (vendor, product, version, part) and return matching CPEs with their associated CVEs. |
+| `get_cpe_cves` | Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. Any attribute accepts `*` and `?` wildcards, so a trailing wildcard on the product covers every product sharing that prefix in one call — prefer this over `search_cpe` when exploring a vendor: `search_cpe` returns at most 100 CPEs per call with no way to page to the rest, and its response can still reach tens of megabytes because each CPE carries its full CVE list. Wildcarding both vendor and product is unbounded and should be avoided. |
+| `search_cpe` | Search for CPEs by component fields (vendor, product, version, part) and return matching CPEs with their associated CVEs. `vulnerable_only` narrows the CVEs listed against each CPE, **not** the CPEs returned — the row count is unchanged by it. |
 | `search_purls` | Return vulnerability findings for one or more Package URLs (PURLs). Each result includes associated CVEs and vulnerability details. |
 | `identify_component` | Convert a vendor, product, and optional version into best-match CPE and PURL identifiers with confidence levels. |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -26,9 +26,10 @@ rather than API records, so it bounds itself and stays outside the byte budget b
 
 **Not yet covered:** the catalogue tools — `list_indices`, `list_backups`,
 `v4_list_advisories`, `v4_list_advisory_backups` — return `{data, total}` with no `returned`
-or `notes`, and are not size-bounded. `list_backups` is the one to know about: it returns all
-516 backups with descriptions, about 62 KB, with no way to ask for names only. Tracked
-separately from the envelope work.
+or `notes`, and are not size-bounded. `list_c2_hostnames` and `list_c2_tags` are further out
+still: they return raw newline-delimited text, so they carry no envelope and no size bound at
+all. `list_backups` is the one to know about: it returns all 516 backups with descriptions,
+about 62 KB, with no way to ask for names only. Tracked separately from the envelope work.
 
 Tools add fields of their own where they have something only they can report — `index` names
 the index a product tool chose on your behalf, `vendors_tried` records the capitalisations
@@ -47,7 +48,8 @@ reported separately in `response_size`, below.) The ones to act on:
 | `the cursor walk is complete` | the other reason a page is empty: you have paged to the end. `total` counts what matched upstream, not what remains, so a larger `limit` will not produce more. |
 | `this tool cannot reach the rest` | `search_cpe` only: there is no `page`, `limit` or `cursor` argument, so the rows beyond the first 100 are unreachable here. Use `get_cpe_cves` with a wildcard CPE, or a backup. |
 | `to reach the rest, set start_cursor` | the tool pages by cursor but only issues one when asked. |
-| `these rows are one page of a larger match set` | report `total`, not the row count. |
+| `these rows are one page of a larger match set`, or `total counts every advisory matching this window` from `list_recent_advisories` | report `total`, not the row count. |
+| `total counts documents matched before`, or `total counts advisories matching this window before` | **the one case where reporting `total` overstates the answer** — the exception to the row above. `v4_search_advisory` and `list_recent_advisories` send `vendor`, `product` and `version` to an endpoint that applies them *after* slicing the page, so `total` counts the coarse match: it is an upper bound on what those filters can return, not a count of withheld records. The rows in front of you are the ones that survived — page on with `next_cursor` for more, and do not report `total` as the number of matching advisories. |
 | `this index describes a population of hosts or events` | the rows are a sample of a population rather than an enumeration. |
 | `total exceeds what a single sequence of pages can reach` | 10,000 records upstream. **Cursor pagination is not subject to it** — pass `start_cursor`, then feed `next_cursor` back as `cursor`. Use a backup of the index only if you want the whole set at once. |
 
@@ -71,10 +73,14 @@ different ways, and the second is the more dangerous:
   are indistinguishable, and the failure points at *"nothing found"* — the answer you should
   be least willing to pass on unchecked.
 
-Two further limits on the five tools that *are* checked. A zero-row response carries no
-parameter list, so it is not checked — safely, because an ignored filter can only widen a
-result, so an empty answer cannot be hiding a narrower one. And a filter an index lists but
-does not honour is invisible from outside.
+Two further limits on the five tools that *are* checked. An index does not always publish its
+parameter list on a zero-row response, and where the list is absent nothing is checked — safely,
+because an ignored filter can only widen a result, so an empty answer cannot be hiding a
+narrower one. This is not a property of the row count or of the index: `vulncheck-nvd2`
+publishes all 19 of its parameters for a `cve` that matches nothing, and none for an unmatched
+`threat_actor`, though it accepts both. So detection does still run on many zero-row responses
+— which is why `epss` reports `date` as dropped even when the query matches nothing. And a
+filter an index lists but does not honour is invisible from outside.
 
 Call `describe_index` before querying an unfamiliar index — it reports the filters that index
 accepts and the values each one takes. For the tools above it is the only check available.

--- a/internal/client/search_index.go
+++ b/internal/client/search_index.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 )
 
@@ -15,6 +16,27 @@ type IndexQueryResult struct {
 	Data       []json.RawMessage `json:"data"`
 	NextCursor string            `json:"next_cursor,omitempty"`
 	Total      int               `json:"total"`
+
+	// FiltersSent are the filter parameters this query actually put on the request, in
+	// upstream spelling. Control parameters — sort, order, limit, cursor — are excluded:
+	// the index does not list them among what it accepts, so including them here would
+	// make every sorted query look like it had a filter dropped.
+	FiltersSent []string `json:"-"`
+
+	// FiltersAccepted is the index's own account of what it accepts, read from
+	// _meta.parameters. Empty means the index did not say, which is not the same as
+	// accepting nothing — see indexResponseMeta.Parameters.
+	FiltersAccepted []string `json:"-"`
+
+	// CursorContinuation records whether this query resumed a walk, which NextCursor
+	// alone cannot say: a plain query returns an empty next_cursor too, so without this
+	// an ordinary empty page is indistinguishable from an exhausted walk.
+	//
+	// Deliberately not set by start_cursor. A first call has walked nothing, so an empty
+	// first page proves only that this page is empty — and announcing the walk complete
+	// there would replace advice that might work ("retry with a larger limit") with
+	// advice that cannot.
+	CursorContinuation bool `json:"-"`
 }
 
 type SearchIndexQuery struct {
@@ -93,6 +115,18 @@ type SearchIndexQuery struct {
 type indexResponseMeta struct {
 	TotalDocuments int    `json:"total_documents"`
 	NextCursor     string `json:"next_cursor,omitempty"`
+
+	// Parameters is the index's own list of the query parameters it accepts, returned
+	// inline with every query. It is the authoritative account of what this index can be
+	// filtered by, and it arrives free: no second request is needed to learn it.
+	//
+	// Some indices omit it on a zero-row response — vulncheck-nvd2 and exploits do,
+	// target-intel does not — so an empty list means "unknown" rather than "accepts
+	// nothing". Every index sampled publishes it on a non-empty response, cursor pages
+	// included.
+	Parameters []struct {
+		Name string `json:"name"`
+	} `json:"parameters,omitempty"`
 }
 
 type indexResponse struct {
@@ -110,6 +144,20 @@ func (c *VulncheckClient) SearchIndex(ctx context.Context, q SearchIndexQuery) (
 		return nil, fmt.Errorf("building URL: %w", err)
 	}
 
+	// filtersSent records which filter parameters actually went on the request, in the
+	// upstream spelling, so a caller can compare them against what the index says it
+	// accepts. Recording it here rather than deriving it from the tool's arguments means
+	// it cannot drift from the query actually sent, and it needs no arg-name translation.
+	//
+	// Only filters go in. sort and order steer the request rather than narrow it and are
+	// not advertised in _meta.parameters, so counting them would report a dropped filter
+	// on every sorted query; they are set below, outside this map, for that reason. limit,
+	// page and cursor never reach here at all.
+	var filtersSent []string
+	sent := func(key string) {
+		filtersSent = append(filtersSent, key)
+	}
+
 	p := u.Query()
 	for key, value := range map[string]string{
 		"cve":                  q.CVE,
@@ -122,8 +170,6 @@ func (c *VulncheckClient) SearchIndex(ctx context.Context, q SearchIndexQuery) (
 		"updatedAtStartDate":   q.UpdatedAtStartDate,
 		"updatedAtEndDate":     q.UpdatedAtEndDate,
 		"date":                 q.Date,
-		"sort":                 q.Sort,
-		"order":                q.Order,
 		"asn":                  q.ASN,
 		"cidr":                 q.CIDR,
 		"country":              q.Country,
@@ -154,21 +200,35 @@ func (c *VulncheckClient) SearchIndex(ctx context.Context, q SearchIndexQuery) (
 	} {
 		if value != "" {
 			p.Set(key, value)
+			sent(key)
 		}
 	}
+	// Controls, not filters: set outside the map above so they are never recorded as
+	// filters sent.
+	if q.Sort != "" {
+		p.Set("sort", q.Sort)
+	}
+	if q.Order != "" {
+		p.Set("order", q.Order)
+	}
+
 	if q.Port > 0 {
 		p.Set("port", strconv.Itoa(q.Port))
+		sent("port")
 	}
 	// contains_cve=false is a meaningful filter (hosts with no associated CVE), so
 	// it is only omitted when the caller left it unset.
 	if q.ContainsCVE != nil {
 		p.Set("contains_cve", strconv.FormatBool(*q.ContainsCVE))
+		sent("contains_cve")
 	}
 	if q.InKEV != nil {
 		p.Set("in_kev", strconv.FormatBool(*q.InKEV))
+		sent("in_kev")
 	}
 	if q.InVCKEV != nil {
 		p.Set("in_vckev", strconv.FormatBool(*q.InVCKEV))
+		sent("in_vckev")
 	}
 	if q.Cursor != "" {
 		p.Set("cursor", q.Cursor)
@@ -218,9 +278,26 @@ func (c *VulncheckClient) SearchIndex(ctx context.Context, q SearchIndexQuery) (
 		items = []json.RawMessage{}
 	}
 
+	// Sorted so the same query always reports the same order, and deduped because at
+	// least one index (vulncheck-nvd2) lists a parameter twice.
+	slices.Sort(filtersSent)
+	accepted := make([]string, 0, len(envelope.Meta.Parameters))
+	for _, param := range envelope.Meta.Parameters {
+		// Skipped as describe_index skips them; an empty list means "the index did not
+		// say", and one blank entry would falsely make it look like it did.
+		if param.Name == "" {
+			continue
+		}
+		accepted = append(accepted, param.Name)
+	}
+	slices.Sort(accepted)
+
 	return &IndexQueryResult{
-		Data:       items,
-		NextCursor: envelope.Meta.NextCursor,
-		Total:      envelope.Meta.TotalDocuments,
+		Data:               items,
+		NextCursor:         envelope.Meta.NextCursor,
+		Total:              envelope.Meta.TotalDocuments,
+		FiltersSent:        filtersSent,
+		FiltersAccepted:    slices.Compact(accepted),
+		CursorContinuation: q.Cursor != "",
 	}, nil
 }

--- a/internal/client/search_index.go
+++ b/internal/client/search_index.go
@@ -120,10 +120,11 @@ type indexResponseMeta struct {
 	// inline with every query. It is the authoritative account of what this index can be
 	// filtered by, and it arrives free: no second request is needed to learn it.
 	//
-	// Some indices omit it on a zero-row response — vulncheck-nvd2 and exploits do,
-	// target-intel does not — so an empty list means "unknown" rather than "accepts
-	// nothing". Every index sampled publishes it on a non-empty response, cursor pages
-	// included.
+	// It can be absent on a zero-row response, so an empty list means "unknown" rather
+	// than "accepts nothing". Which zero-row responses carry it is not a property of the
+	// index: vulncheck-nvd2 publishes all 19 of its parameters for a cve that matches
+	// nothing and none for an unmatched threat_actor, though it accepts both. Every index
+	// sampled publishes it on a non-empty response, cursor pages included.
 	Parameters []struct {
 		Name string `json:"name"`
 	} `json:"parameters,omitempty"`

--- a/internal/client/search_index_test.go
+++ b/internal/client/search_index_test.go
@@ -403,8 +403,8 @@ func TestSearchIndex_RecordsFiltersSentAndAccepted(t *testing.T) {
 }
 
 // An absent parameter list means the index did not say what it accepts, which is not the
-// same as accepting nothing. Every zero-row response omits it, so treating an empty list as
-// "everything was dropped" would fire on every empty result.
+// same as accepting nothing. Zero-row responses often omit it, so treating an empty list as
+// "everything was dropped" would fire on results that dropped nothing.
 func TestSearchIndex_AbsentParameterListIsNotEmptyAcceptance(t *testing.T) {
 	c := newAPITestClient(func(*http.Request) (*http.Response, error) {
 		return jsonResp(http.StatusOK, map[string]any{

--- a/internal/client/search_index_test.go
+++ b/internal/client/search_index_test.go
@@ -363,3 +363,134 @@ func TestSearchIndex_OmitsUnsetKEVFlags(t *testing.T) {
 		assert.False(t, present, "%s must be absent when unset", key)
 	}
 }
+
+// TestSearchIndex_RecordsFiltersSentAndAccepted covers the two halves of the
+// silent-filter-drop defence: what this query actually filtered by, and what the index says
+// it accepts. Both have to be right for the comparison downstream to mean anything.
+func TestSearchIndex_RecordsFiltersSentAndAccepted(t *testing.T) {
+	c := newAPITestClient(func(*http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, map[string]any{
+			"_meta": map[string]any{
+				"total_documents": 5,
+				// Duplicated deliberately: vulncheck-nvd2 really does list `date`
+				// twice, and a repeated name must not reach the caller twice.
+				"parameters": []any{
+					map[string]any{"name": "cve"},
+					map[string]any{"name": "date"},
+					map[string]any{"name": "date"},
+				},
+			},
+			"data": []any{},
+		}), nil
+	})
+
+	result, err := c.SearchIndex(context.Background(), SearchIndexQuery{
+		Index:       "vulncheck-nvd2",
+		CVE:         "CVE-2021-44228",
+		ThreatActor: "UNC2630",
+		// Controls, not filters. The index does not advertise these, so counting them
+		// as filters would report a dropped filter on every sorted or paged query.
+		Sort:  "_timestamp",
+		Order: "desc",
+		Limit: 10,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"cve", "threat_actor"}, result.FiltersSent,
+		"filters are recorded in upstream spelling, sorted, controls excluded")
+	assert.Equal(t, []string{"cve", "date"}, result.FiltersAccepted,
+		"the index's own list, sorted and deduped")
+}
+
+// An absent parameter list means the index did not say what it accepts, which is not the
+// same as accepting nothing. Every zero-row response omits it, so treating an empty list as
+// "everything was dropped" would fire on every empty result.
+func TestSearchIndex_AbsentParameterListIsNotEmptyAcceptance(t *testing.T) {
+	c := newAPITestClient(func(*http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, map[string]any{
+			"_meta": map[string]any{"total_documents": 0},
+			"data":  []any{},
+		}), nil
+	})
+
+	result, err := c.SearchIndex(context.Background(), SearchIndexQuery{
+		Index: "vulncheck-nvd2",
+		CVE:   "CVE-2021-44228",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"cve"}, result.FiltersSent)
+	assert.Empty(t, result.FiltersAccepted, "unknown, not empty")
+}
+
+// A blank parameter name must not count as a published list. describe_index skips these
+// already; if this side did not, one empty entry would make FiltersAccepted non-empty and
+// every filter sent would look dropped.
+func TestSearchIndex_SkipsBlankParameterNames(t *testing.T) {
+	c := newAPITestClient(func(*http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, map[string]any{
+			"_meta": map[string]any{
+				"total_documents": 5,
+				"parameters":      []any{map[string]any{"name": ""}},
+			},
+			"data": []any{},
+		}), nil
+	})
+
+	result, err := c.SearchIndex(context.Background(), SearchIndexQuery{
+		Index: "vulncheck-nvd2", CVE: "CVE-2021-44228",
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, result.FiltersAccepted, "a blank name is not a parameter")
+}
+
+// CursorContinuation is what separates an exhausted cursor walk from an ordinary empty
+// page: a plain query returns an empty next_cursor too, so NextCursor alone cannot tell them
+// apart. start_cursor does not count — a first call has walked nothing.
+func TestSearchIndex_RecordsWhetherACursorWasResumed(t *testing.T) {
+	respond := func(*http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, map[string]any{
+			"_meta": map[string]any{"total_documents": 5},
+			"data":  []any{},
+		}), nil
+	}
+
+	for _, tt := range []struct {
+		name  string
+		query SearchIndexQuery
+		want  bool
+	}{
+		{"plain query", SearchIndexQuery{Index: "vulncheck-nvd2"}, false},
+		{"first page of a walk", SearchIndexQuery{Index: "vulncheck-nvd2", StartCursor: true}, false},
+		{"resumed walk", SearchIndexQuery{Index: "vulncheck-nvd2", Cursor: "abc"}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := newAPITestClient(respond).SearchIndex(context.Background(), tt.query)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result.CursorContinuation)
+		})
+	}
+}
+
+// The boolean and numeric filters go through a different code path from the string map, so
+// they need their own check that they are recorded at all.
+func TestSearchIndex_RecordsNonStringFilters(t *testing.T) {
+	c := newAPITestClient(func(*http.Request) (*http.Response, error) {
+		return jsonResp(http.StatusOK, map[string]any{
+			"_meta": map[string]any{"total_documents": 0},
+			"data":  []any{},
+		}), nil
+	})
+
+	yes := true
+	result, err := c.SearchIndex(context.Background(), SearchIndexQuery{
+		Index:       "target-intel",
+		Port:        443,
+		ContainsCVE: &yes,
+		InKEV:       &yes,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"contains_cve", "in_kev", "port"}, result.FiltersSent)
+}

--- a/internal/client/search_purls.go
+++ b/internal/client/search_purls.go
@@ -8,7 +8,11 @@ import (
 )
 
 type SearchPURLsResult struct {
-	Data  []vulncheck.PurlBatchVulnFinding `json:"data,omitempty"`
+	// No omitempty on Data. This type is built here and read by the server rather than
+	// marshalled, so the tags are informational — but omitempty on a row slice is the
+	// hazard that made an empty PURL result indistinguishable from a missing field, and
+	// leaving it here invites the same mistake from whoever marshals this next.
+	Data  []vulncheck.PurlBatchVulnFinding `json:"data"`
 	Total int                              `json:"total"`
 }
 

--- a/internal/server/cap.go
+++ b/internal/server/cap.go
@@ -131,6 +131,10 @@ type capReport struct {
 
 	// RowsReturned is set only when the row list was trimmed. It is not a limit — rows
 	// are filled greedily — it saves the caller counting.
+	//
+	// It duplicates the envelope's `returned` for every tool here, but this walk is
+	// generic over decoded JSON: for a payload with no `returned` field, this is the only
+	// account of how many rows survived.
 	RowsReturned int `json:"rows_returned,omitempty"`
 
 	// RowsRemoved is how many rows did not fit. RemovedIDs names at most maxNamedRows of
@@ -259,11 +263,12 @@ func arraysCappedReport(originalBytes, limit int, capped map[string]int, total i
 
 // findRowList reports the JSON Pointer of the response's row list, or "" if it has none.
 //
-// The row list is the largest top-level array by serialized size. It is derived rather
-// than declared because the tools do not agree on where it lives: most carry rows under
-// `data` and one returns a flat list of CVE IDs under `cves`. An outer array always
-// contains its children, so the outermost is always the largest, and size breaks the tie
-// against small sibling arrays such as notes.
+// The row list is the largest top-level array by serialized size. It is derived rather than
+// declared so that the walk stays generic: every tool now carries its rows under `data`, but
+// nothing in the type system enforces that, and a tool added later that puts them elsewhere
+// still gets bounded correctly. An outer array always contains its children, so the
+// outermost is always the largest, and size breaks the tie against small sibling arrays such
+// as notes.
 //
 // The document-root case below is unreachable from today's handlers, which all return an
 // object. It stays because this walk is documented as generic over decoded JSON, and the
@@ -715,11 +720,20 @@ func rowName(row any) string {
 }
 
 func recordCappedNote(limit int) string {
+	// The floor rung is 1, so the singular case is reached routinely rather than being a
+	// theoretical edge — "shortened to 1 items" in a note whose whole job is to be believed
+	// reads as a bug in the thing reporting the bug.
+	item, entry := "items", "entries"
+	if limit == 1 {
+		item, entry = "item", "entry"
+	}
+
 	return fmt.Sprintf("ARRAY COUNTS IN THIS RESPONSE ARE NOT REAL COUNTS: every array was "+
-		"shortened to %d items to keep the response within a usable context budget. Read the "+
+		"shortened to %d %s to keep the response within a usable context budget. Read the "+
 		"true length of each from capped below before reporting any quantity — an array showing "+
-		"%d entries may have thousands. Nothing else was altered: the record is otherwise "+
-		"complete and unmodified. For the full record, fetch it via the API or CLI", limit, limit)
+		"%d %s may have thousands. Nothing else was altered: the record is otherwise "+
+		"complete and unmodified. For the full record, fetch it via the API or CLI",
+		limit, item, limit, entry)
 }
 
 // rowsTrimmedNote describes a trimmed row list. Rows reach this path only via the floor

--- a/internal/server/cap_test.go
+++ b/internal/server/cap_test.go
@@ -237,16 +237,16 @@ func TestCapResponse_UnshrinkableLeadingRowIsSkippedNotFatal(t *testing.T) {
 }
 
 func TestCapResponse_FlatStringListIsFilledNotLaddered(t *testing.T) {
-	// get_cpe_cves returns a flat list of IDs under `cves`. Treating that as an inner
-	// array would shorten it to a ladder rung; treating it as the row list returns as
-	// many IDs as fit, which is two orders of magnitude more useful.
+	// get_cpe_cves returns a flat list of IDs rather than records. Treating that as an
+	// inner array would shorten it to a ladder rung; treating it as the row list returns
+	// as many IDs as fit, which is two orders of magnitude more useful.
 	cves := make([]any, 40_000)
 	for i := range cves {
 		cves[i] = fmt.Sprintf("CVE-2024-%05d", i)
 	}
 	encoded := mustMarshal(t, map[string]any{
 		"cpe":   "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*",
-		"cves":  cves,
+		"data":  cves,
 		"total": 40_000,
 	})
 
@@ -254,20 +254,20 @@ func TestCapResponse_FlatStringListIsFilledNotLaddered(t *testing.T) {
 	require.NotNil(t, report)
 
 	assert.LessOrEqual(t, len(out), defaultResponseBudget)
-	assert.Equal(t, 40_000, report.Capped["/cves"])
+	assert.Equal(t, 40_000, report.Capped["/data"])
 	assert.Greater(t, report.RowsReturned, 1_000,
 		"a flat ID list must be filled, not shortened to a ladder rung")
 
 	var payload struct {
 		CPE   string   `json:"cpe"`
-		CVEs  []string `json:"cves"`
+		Data  []string `json:"data"`
 		Total int      `json:"total"`
 	}
 	require.NoError(t, json.Unmarshal(out, &payload))
 	assert.Equal(t, 40_000, payload.Total, "total comes from the API and stays correct")
-	assert.Len(t, payload.CVEs, report.RowsReturned)
-	assert.Equal(t, "CVE-2024-00000", payload.CVEs[0])
-	assert.NotEmpty(t, report.RemovedIDs["/cves"], "a string row is its own identifier")
+	assert.Len(t, payload.Data, report.RowsReturned)
+	assert.Equal(t, "CVE-2024-00000", payload.Data[0])
+	assert.NotEmpty(t, report.RemovedIDs["/data"], "a string row is its own identifier")
 }
 
 func TestReportPath_NamesTheDocumentRootLegibly(t *testing.T) {

--- a/internal/server/contract_test.go
+++ b/internal/server/contract_test.go
@@ -275,7 +275,7 @@ func TestResponseSizeContract_SmallResponsesAreUntouched(t *testing.T) {
 	})
 
 	assert.Len(t, result.Content, 1, "nothing was done, so nothing is reported")
-	assert.JSONEq(t, `{"data":[{"cve":"CVE-2024-1"}],"total":1}`, payloadText(t, result))
+	assert.JSONEq(t, `{"data":[{"cve":"CVE-2024-1"}],"returned":1,"total":1}`, payloadText(t, result))
 }
 
 type toolCall func() (*mcp.CallToolResult, any, error)

--- a/internal/server/envelope.go
+++ b/internal/server/envelope.go
@@ -1,0 +1,71 @@
+package server
+
+// envelope is the core every record-returning tool carries alongside its rows.
+//
+// It exists because the twelve tools that return API records grew their reporting
+// separately: the six added after #46 carry a full account of what happened to a query,
+// and the six from the first release carried none, so an empty page and a genuine no-match
+// were indistinguishable on most of them.
+//
+// Tool-specific fields stay with their tools rather than moving here. `index` records which
+// index a product tool chose on the caller's behalf, and `vendors_tried` is the audit trail
+// of a case-variant retry — facts only those tools can report, and flattening them into a
+// common shape would delete real information to buy symmetry.
+//
+// Each tool declares its own Data field and embeds this before it, so the core marshals
+// ahead of the rows. Data is not part of the core because its element type differs per
+// tool, and a generic would buy nothing: the field is one line either way.
+//
+// Do not embed this alongside another embedded struct carrying the same JSON names.
+// encoding/json drops every conflicting name at the same depth and returns no error, so
+// `total` and `next_cursor` would vanish silently.
+type envelope struct {
+	// Returned is how many rows the payload actually carries.
+	//
+	// Deliberately not omitempty. Zero is the single most important value it reports —
+	// "this query matched nothing" as distinct from "this field is absent because
+	// something went wrong" — and it is the field capResult's correctReturned rewrites
+	// after trimming rows, which it only does for a tool that already carries it.
+	Returned int `json:"returned"`
+
+	// Total is how many rows matched upstream, which stays true when rows are trimmed for
+	// size. total > returned is the signal that this is a page or a sample rather than
+	// the whole set. Not omitempty, for the same reason as Returned.
+	//
+	// Unpaginated tools set it to len(data), which is truthful rather than padding: after
+	// trimming, returned drops and total does not, so the gap still reports withholding.
+	Total int `json:"total"`
+
+	// NextCursor is omitempty because its absence is meaningful and unambiguous: there is
+	// no next page. Unlike a zero count, an empty cursor cannot be read as a missing field.
+	NextCursor string `json:"next_cursor,omitempty"`
+
+	// Notes report what the API did to the query — filters it ignored, a page that is
+	// empty for a reason other than absence, a total beyond what paging can reach.
+	//
+	// What MCP did to the response belongs in response_size instead. The split is
+	// deliberate: one describes the answer, the other the transport.
+	Notes []string `json:"notes,omitempty"`
+}
+
+// newEnvelope fills the core from a row count, a total and a cursor, so the nine tools that
+// build one cannot drift in how they do it.
+func newEnvelope(returned, total int, cursor string) envelope {
+	return envelope{Returned: returned, Total: total, NextCursor: cursor}
+}
+
+// The vocabulary below is shared across tools rather than per-endpoint, because "these rows
+// are not the whole answer" is the same fact whichever tool reports it. Each tool adds its
+// own route clause, since how to reach the rest is the part that differs.
+const (
+	// partialSetNote is true of every tool: the rows are one page of a larger match set,
+	// so the count in front of the caller is not the answer to "how many".
+	partialSetNote = "these rows are one page of a larger match set, and total is the size of the " +
+		"whole of it — report total rather than counting the rows returned"
+
+	// cursorRouteNote names the route for tools that page by cursor but only issue one
+	// when asked, so a response that carries no next_cursor does not reveal that a route
+	// exists at all.
+	cursorRouteNote = "to reach the rest, set start_cursor true on the first call and pass each " +
+		"next_cursor back as cursor"
+)

--- a/internal/server/envelope_test.go
+++ b/internal/server/envelope_test.go
@@ -1,0 +1,301 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulncheck-oss/mcp/internal/client"
+	vulncheck "github.com/vulncheck-oss/sdk-go-v2/v2"
+)
+
+// envelopeCase is one record-returning tool, run against a mock that returns rowCount rows
+// and, where the tool paginates, a cursor.
+type envelopeCase struct {
+	name string
+
+	// paginates records whether next_cursor is meaningful. It is omitempty, so asserting
+	// on it for a tool that never sets one would pass vacuously and prove nothing.
+	paginates bool
+
+	run func(t *testing.T, rowCount int) *mcp.CallToolResult
+}
+
+// envelopeCases covers the twelve tools that call capResult — the same set
+// TestResponseSizeContract enumerates, which is what makes "record-returning tool" a
+// definition in the code rather than a judgement call.
+func envelopeCases() []envelopeCase {
+	// rawRows builds n trivially small records, so nothing here is near the byte budget:
+	// this contract is about the unshortened path.
+	rawRows := func(n int) []json.RawMessage {
+		rows := make([]json.RawMessage, n)
+		for i := range rows {
+			rows[i] = json.RawMessage(`{"cve":"CVE-2024-0001"}`)
+		}
+		return rows
+	}
+	indexResult := func(n int) *client.IndexQueryResult {
+		return &client.IndexQueryResult{Data: rawRows(n), Total: 500, NextCursor: "next"}
+	}
+	indexMock := func(n int) *mockClient {
+		return &mockClient{searchIndexFn: func(context.Context, client.SearchIndexQuery) (*client.IndexQueryResult, error) {
+			return indexResult(n), nil
+		}}
+	}
+
+	return []envelopeCase{
+		{
+			name:      "search_index",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				return runTool(t, indexMock(n), func(vc client.Client) toolCall {
+					return call(MakeSearchIndexHandler(vc), searchIndexArgs{Index: "vulncheck-nvd2"})
+				})
+			},
+		},
+		{
+			name:      "search_target_intel",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				return runTool(t, indexMock(n), func(vc client.Client) toolCall {
+					return call(MakeSearchTargetIntelHandler(vc), searchTargetIntelArgs{CVE: "CVE-2021-44228"})
+				})
+			},
+		},
+		{
+			name:      "search_ip_intel",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				return runTool(t, indexMock(n), func(vc client.Client) toolCall {
+					return call(MakeSearchIPIntelHandler(vc), searchIPIntelArgs{})
+				})
+			},
+		},
+		{
+			name:      "search_canaries",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				return runTool(t, indexMock(n), func(vc client.Client) toolCall {
+					return call(MakeSearchCanariesHandler(vc), searchCanariesArgs{})
+				})
+			},
+		},
+		{
+			name:      "search_curated_exploits",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				return runTool(t, indexMock(n), func(vc client.Client) toolCall {
+					return call(MakeSearchCuratedExploitsHandler(vc), searchCuratedExploitsArgs{})
+				})
+			},
+		},
+		{
+			name:      "search_advisory",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				mock := &mockClient{searchAdvisoryFn: func(context.Context, client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+					return &client.SearchAdvisoryResult{Data: rawRows(n), Total: int32(n), NextCursor: "next"}, nil //nolint:gosec // G115: n is a row count set by this test, never near the int32 bound
+				}}
+				return runTool(t, mock, func(vc client.Client) toolCall {
+					return call(MakeSearchAdvisoryHandler(vc), searchAdvisoryArgs{Name: "ghsa"})
+				})
+			},
+		},
+		{
+			name:      "list_recent_advisories",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				rows := make([]json.RawMessage, n)
+				for i := range rows {
+					rows[i] = json.RawMessage(`{"cveMetadata":{"cveId":"CVE-2024-0001"}}`)
+				}
+				mock := &mockClient{searchAdvisoryFn: func(context.Context, client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+					return &client.SearchAdvisoryResult{Data: rows, Total: int32(n), NextCursor: "next"}, nil //nolint:gosec // G115: as above
+				}}
+				return runTool(t, mock, func(vc client.Client) toolCall {
+					return call(MakeListRecentAdvisoriesHandler(vc), listRecentAdvisoriesArgs{})
+				})
+			},
+		},
+		{
+			name:      "search_cve",
+			paginates: true,
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				hits := make([]vulncheck.IndexCveSearchHit, n)
+				mock := &mockClient{searchCVEFn: func(context.Context, client.SearchCVEQuery) (*client.SearchCVEResult, error) {
+					return &client.SearchCVEResult{Data: hits, Total: int32(n), NextCursor: "next"}, nil //nolint:gosec // G115: as above
+				}}
+				return runTool(t, mock, func(vc client.Client) toolCall {
+					return call(MakeSearchCVEHandler(vc), searchCVEArgs{CVE: "CVE-2021-44228"})
+				})
+			},
+		},
+		{
+			name: "search_cpe",
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				rows := make([]vulncheck.SearchResponseDataOut, n)
+				mock := &mockClient{searchCPEFn: func(context.Context, client.SearchCPEQuery) (*client.SearchCPEResult, error) {
+					return &client.SearchCPEResult{Data: rows, Total: n}, nil
+				}}
+				return runTool(t, mock, func(vc client.Client) toolCall {
+					return call(MakeSearchCPEHandler(vc), searchCPEArgs{Vendor: "apache"})
+				})
+			},
+		},
+		{
+			name: "search_purls",
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				// An empty slice rather than nil, because that is what client.SearchPURLs
+				// guarantees. The defect this tool had was returning the client result
+				// directly, whose Data was tagged omitempty and so vanished when empty.
+				rows := make([]vulncheck.PurlBatchVulnFinding, n)
+				mock := &mockClient{searchPURLsFn: func(context.Context, []string) (*client.SearchPURLsResult, error) {
+					return &client.SearchPURLsResult{Data: rows, Total: n}, nil
+				}}
+				return runTool(t, mock, func(vc client.Client) toolCall {
+					return call(MakeSearchPURLsHandler(vc), searchPURLsArgs{PURLs: []string{"pkg:npm/x@1"}})
+				})
+			},
+		},
+		{
+			name: "get_cpe_cves",
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				cves := make([]string, n)
+				for i := range cves {
+					cves[i] = "CVE-2024-0001"
+				}
+				mock := &mockClient{getCPECVEsFn: func(context.Context, string, bool) (*client.CPECVEsResult, error) {
+					return &client.CPECVEsResult{CVEs: cves, Total: n}, nil
+				}}
+				return runTool(t, mock, func(vc client.Client) toolCall {
+					return call(MakeGetCPECVEsHandler(vc), getCPECVEsArgs{CPE: "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"})
+				})
+			},
+		},
+		{
+			name: "identify_component",
+			run: func(t *testing.T, n int) *mcp.CallToolResult {
+				rows := make([]client.IdentifyResult, n)
+				mock := &mockClient{identifyComponentFn: func(context.Context, string, string, string) ([]client.IdentifyResult, error) {
+					return rows, nil
+				}}
+				return runTool(t, mock, func(vc client.Client) toolCall {
+					return call(MakeIdentifyComponentHandler(vc), identifyComponentArgs{Vendor: "a", Product: "b"})
+				})
+			},
+		},
+	}
+}
+
+// decodePayload returns the response as a bare map, so a field's *presence* can be asserted
+// rather than the zero value a typed decode would invent for a field that is missing.
+func decodePayload(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	return decodeNumeric(t, payloadText(t, result))
+}
+
+// decodeNumeric decodes with UseNumber, so a row count arrives as json.Number rather than
+// float64 and can be compared exactly. These are integer counts: comparing them as floats
+// invites an epsilon, and an epsilon on "how many rows are present" is meaningless. cap.go
+// decodes the same way, for the neighbouring reason that float64 loses large integers.
+func decodeNumeric(t *testing.T, encoded string) map[string]any {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(encoded))
+	dec.UseNumber()
+	var payload map[string]any
+	require.NoError(t, dec.Decode(&payload))
+	return payload
+}
+
+// TestEnvelopeContract is the enforcement mechanism for the response envelope.
+//
+// Every tool that returns API records reports the same core — the rows, how many are
+// present, how many matched, and where the next page is — so a caller does not have to know
+// which tool it called to read the answer. Twelve tools grew that reporting separately and
+// six of them never got it; this is what stops that recurring.
+func TestEnvelopeContract(t *testing.T) {
+	for _, tc := range envelopeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := decodePayload(t, tc.run(t, 3))
+
+			require.Contains(t, payload, "data", "rows live under data on every tool")
+			require.Contains(t, payload, "returned", "a tool must say how many rows it returned")
+			require.Contains(t, payload, "total", "a tool must say how many matched")
+
+			assert.Equal(t, json.Number("3"), payload["returned"],
+				"returned counts the rows actually present")
+
+			if tc.paginates {
+				assert.Equal(t, "next", payload["next_cursor"],
+					"a paginating tool passes the cursor through")
+			}
+		})
+	}
+}
+
+// TestEnvelopeContract_EmptyResultsAreExplicit is the half that matters most.
+//
+// An empty result must be visibly empty rather than absent. A missing `data` or a missing
+// `returned` reads as a malfunction, and "nothing matched" and "something went wrong" must
+// not look the same to a caller about to report that nothing is affected.
+func TestEnvelopeContract_EmptyResultsAreExplicit(t *testing.T) {
+	for _, tc := range envelopeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := decodePayload(t, tc.run(t, 0))
+
+			require.Contains(t, payload, "data",
+				"data is present even when empty — absence is not a way to say zero")
+			require.Contains(t, payload, "returned",
+				"returned is present at zero, which is the value most worth reporting")
+			assert.Equal(t, json.Number("0"), payload["returned"])
+			require.Contains(t, payload, "total")
+		})
+	}
+}
+
+// TestEnvelopeMarshalsEveryField guards the failure that has no symptom.
+//
+// encoding/json drops *every* conflicting field name at a given depth and returns no error.
+// searchAdvisoryResponse embedded *client.SearchAdvisoryResult, which promotes `total` and
+// `next_cursor` to the depth envelope also occupies, so adding the envelope without
+// flattening it first would have emitted neither — err == nil, and nothing else in the
+// suite watching, because TestResponseSizeContract asserts on the size report.
+//
+// This walks the tools' own result types rather than a hand-written copy of their shape, so
+// a future struct that reintroduces the collision fails here.
+func TestEnvelopeMarshalsEveryField(t *testing.T) {
+	core := envelope{Returned: 1, Total: 42, NextCursor: "abc", Notes: []string{"note"}}
+
+	results := map[string]any{
+		"searchIndexResult":        searchIndexResult{Data: []json.RawMessage{json.RawMessage(`{}`)}, envelope: core},
+		"searchAdvisoryResponse":   searchAdvisoryResponse{Data: []json.RawMessage{json.RawMessage(`{}`)}, envelope: core},
+		"productResponse":          productResponse{Index: "i", Data: []json.RawMessage{json.RawMessage(`{}`)}, envelope: core},
+		"recentAdvisoriesResponse": recentAdvisoriesResponse{Data: []advisoryDigestRow{{}}, Window: "w", envelope: core},
+		"searchCVEResult":          searchCVEResult{Data: []vulncheck.IndexCveSearchHit{{}}, envelope: core},
+		"searchCPEResult":          searchCPEResult{Data: []vulncheck.SearchResponseDataOut{{}}, envelope: core},
+		"searchPURLsResult":        searchPURLsResult{Data: []vulncheck.PurlBatchVulnFinding{{}}, envelope: core},
+		"identifyComponentResult":  identifyComponentResult{Data: []client.IdentifyResult{{}}, envelope: core},
+		"getCPECVEsResult":         getCPECVEsResult{CPE: "c", Data: []string{"CVE-2024-0001"}, envelope: core},
+		"searchDocsResult":         searchDocsResult{Query: "q", Data: []DocPage{{}}, envelope: core},
+	}
+
+	for name, v := range results {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := json.Marshal(v)
+			require.NoError(t, err)
+
+			got := decodeNumeric(t, string(encoded))
+
+			for _, field := range []string{"data", "returned", "total", "next_cursor", "notes"} {
+				assert.Contains(t, got, field,
+					"%s: a field colliding with an embedded struct is dropped without error", field)
+			}
+			assert.Equal(t, json.Number("42"), got["total"], "total must survive, not be silently dropped")
+			assert.Equal(t, "abc", got["next_cursor"])
+		})
+	}
+}

--- a/internal/server/get_cpe_cves.go
+++ b/internal/server/get_cpe_cves.go
@@ -18,17 +18,23 @@ var GetCPECVEsTool = &mcp.Tool{
 	Title: "Get CPE CVEs",
 	Description: "Return all CVE IDs associated with a CPE 2.3 string. Optionally restrict to CVEs where the CPE is confirmed vulnerable. " +
 		"Any attribute accepts '*' and '?' wildcards, so a trailing wildcard on the product covers every product sharing that prefix in one call — " +
-		"prefer this over search_cpe when exploring a vendor, because search_cpe returns every matching CPE and its response can reach tens of megabytes. " +
+		"prefer this over search_cpe when exploring a vendor: search_cpe returns at most 100 CPEs per call with no way to page to the rest, and its response can still reach tens of megabytes because each CPE carries its full CVE list. " +
 		"Wildcarding both vendor and product is unbounded and should be avoided.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
 }
 
+// getCPECVEsResult returns the CVE IDs under `data`, not `cves`.
+//
+// This tool used to be the only one naming its rows after their content. `data` is where
+// every other tool puts them — see identifyComponentResult, which made the same choice for
+// the same reason — and a caller should not have to know which tool it called to find the
+// rows. The list is still flat CVE ID strings; only the field name changed.
 type getCPECVEsResult struct {
-	CPE   string   `json:"cpe"`
-	CVEs  []string `json:"cves"`
-	Total int      `json:"total"`
+	envelope
+	CPE  string   `json:"cpe"`
+	Data []string `json:"data"`
 }
 
 func registerGetCPECVEs(srv *mcp.Server, vc client.Client) {
@@ -43,9 +49,9 @@ func MakeGetCPECVEsHandler(vc client.Client) mcp.ToolHandlerFor[getCPECVEsArgs, 
 		}
 
 		return capResult(getCPECVEsResult{
-			CPE:   args.CPE,
-			CVEs:  result.CVEs,
-			Total: result.Total,
+			envelope: newEnvelope(len(result.CVEs), result.Total, ""),
+			CPE:      args.CPE,
+			Data:     result.CVEs,
 		})
 	}
 }

--- a/internal/server/get_cpe_cves_test.go
+++ b/internal/server/get_cpe_cves_test.go
@@ -82,7 +82,7 @@ func TestMakeGetCPECVEsHandler(t *testing.T) {
 			require.NoError(t, json.Unmarshal([]byte(text), &got))
 			assert.Equal(t, tt.args.CPE, got.CPE)
 			assert.Equal(t, tt.wantTotal, got.Total)
-			assert.Equal(t, tt.wantCVEs, got.CVEs)
+			assert.Equal(t, tt.wantCVEs, got.Data)
 		})
 	}
 }

--- a/internal/server/identify_component.go
+++ b/internal/server/identify_component.go
@@ -17,13 +17,15 @@ type identifyComponentArgs struct {
 // identifyComponentResult wraps the matches in an envelope rather than marshalling the
 // bare array the API hands back.
 //
-// The array is the only thing this tool has to say, so an envelope looks like ceremony.
-// It earns its place at the layer below: nothing can be a sibling of a JSON array, so a
-// bare array is the one shape that cannot carry the response_size report inside itself.
-// Wrapping it here means capResult has one shape to serve instead of two, and the report
-// always travels with the data it describes. `data` rather than `matches` because that is
-// where every other tool puts its rows.
+// Two reasons, and the wrapper predates the second. Nothing can be a sibling of a JSON
+// array, so a bare array is the one shape that cannot carry the response_size report inside
+// itself; wrapping it means capResult has one shape to serve instead of two, and the report
+// always travels with the data it describes. The tool now also reports returned and total
+// like every other, which a bare array has nowhere to put.
+//
+// `data` rather than `matches` because that is where every other tool puts its rows.
 type identifyComponentResult struct {
+	envelope
 	Data []client.IdentifyResult `json:"data"`
 }
 
@@ -47,6 +49,12 @@ func MakeIdentifyComponentHandler(vc client.Client) mcp.ToolHandlerFor[identifyC
 			return nil, nil, fmt.Errorf("identifying component %q %q: %w", args.Vendor, args.Product, err)
 		}
 
-		return capResult(identifyComponentResult{Data: results})
+		// This tool does not paginate, so total is the row count rather than a larger
+		// matching set. That is truthful, and it stays useful: capResult lowers returned
+		// if it trims rows, leaving total > returned to report the withholding.
+		return capResult(identifyComponentResult{
+			envelope: newEnvelope(len(results), len(results), ""),
+			Data:     results,
+		})
 	}
 }

--- a/internal/server/list_recent_advisories.go
+++ b/internal/server/list_recent_advisories.go
@@ -88,13 +88,10 @@ type advisoryDigestRow struct {
 }
 
 type recentAdvisoriesResponse struct {
-	Data       []advisoryDigestRow `json:"data"`
-	Returned   int                 `json:"returned"`
-	Total      int32               `json:"total"`
-	Window     string              `json:"window"`
-	Providers  map[string]int      `json:"providers,omitempty"`
-	NextCursor string              `json:"next_cursor,omitempty"`
-	Notes      []string            `json:"notes,omitempty"`
+	envelope
+	Window    string              `json:"window"`
+	Providers map[string]int      `json:"providers,omitempty"`
+	Data      []advisoryDigestRow `json:"data"`
 }
 
 // advisoryDigestSource is the subset of a CVE 5.x record the digest reads. Titles and
@@ -263,16 +260,14 @@ func buildRecentAdvisories(result *client.SearchAdvisoryResult, q digestQuery) r
 	}
 
 	response := recentAdvisoriesResponse{
-		Data:       rows,
-		Returned:   len(rows),
-		Total:      result.Total,
-		Window:     describeWindow(q.UpdatedAfter, q.UpdatedBefore),
-		Providers:  topProviders(providers),
-		NextCursor: result.NextCursor,
-		Notes:      []string{digestNote},
+		envelope:  newEnvelope(len(rows), int(result.Total), result.NextCursor),
+		Window:    describeWindow(q.UpdatedAfter, q.UpdatedBefore),
+		Providers: topProviders(providers),
+		Data:      rows,
 	}
+	response.Notes = []string{digestNote}
 
-	if int(result.Total) > len(rows) {
+	if response.Total > response.Returned {
 		response.Notes = append(response.Notes, digestPartialNote)
 	}
 	// A single feed dominating usually means it is mid-bulk-update, which makes the

--- a/internal/server/list_recent_advisories.go
+++ b/internal/server/list_recent_advisories.go
@@ -39,6 +39,18 @@ const (
 	digestPartialNote = "total counts every advisory matching this window; these rows are the current " +
 		"page of it, not the whole set"
 
+	// The digest counterpart to search_advisory's totalMismatchNote, and it is here for the
+	// same reason: /v4/advisory applies vendor and product after slicing the page, so with
+	// either of them in play total counts the coarse match rather than the filtered one.
+	// digestPartialNote would then instruct the caller to report a number far above the
+	// answer. Verified live — vendor=Ivanti&updatedAfter=now-30d returns 23 rows against a
+	// total of 142, and "report total" would turn 23 Ivanti advisories into 142.
+	digestFilteredTotalNote = "total counts advisories matching this window before the API's exact " +
+		"vendor and product filters run, so it is an upper bound on what those filters can return " +
+		"rather than a count of withheld records — do NOT report it as the number of matching " +
+		"advisories. The rows in this response are the ones that survived; if next_cursor is " +
+		"present, further pages may add more"
+
 	// The advice deliberately does not suggest changing the window. Whichever feed is
 	// part-way through a bulk update fills the page, and which feed that is depends on
 	// when the call is made, so a narrower or wider window lands on a different
@@ -234,6 +246,9 @@ func MakeListRecentAdvisoriesHandler(vc client.Client) mcp.ToolHandlerFor[listRe
 			UpdatedAfter:  updatedAfter,
 			UpdatedBefore: args.UpdatedBefore,
 			Name:          args.Name,
+			Vendor:        args.Vendor,
+			Product:       args.Product,
+			Cursor:        args.Cursor,
 		})
 
 		return capResult(response)
@@ -242,10 +257,26 @@ func MakeListRecentAdvisoriesHandler(vc client.Client) mcp.ToolHandlerFor[listRe
 
 // digestQuery carries the request fields the response needs to describe itself,
 // rather than passing several interchangeable strings positionally.
+//
+// Vendor and Product are carried to be reasoned about rather than reported: they change what
+// total means, because the API applies both after slicing the page. Leaving them out is what
+// let this tool present a pre-filter count as the size of the window. Cursor is carried for
+// the same kind of reason: it says whether a walk is already under way, which is what decides
+// whether naming the cursor route is advice or noise.
 type digestQuery struct {
 	UpdatedAfter  string
 	UpdatedBefore string
 	Name          string
+	Vendor        string
+	Product       string
+	Cursor        string
+}
+
+// postSliceFiltered defers to search_advisory's predicate rather than repeating its
+// condition. Which filters narrow a page after it has been sliced is a property of
+// /v4/advisory, which both tools call, so the two must not be able to disagree about it.
+func (q digestQuery) postSliceFiltered() bool {
+	return postSliceFiltered(client.SearchAdvisoryQuery{Vendor: q.Vendor, Product: q.Product})
 }
 
 func buildRecentAdvisories(result *client.SearchAdvisoryResult, q digestQuery) recentAdvisoriesResponse {
@@ -268,7 +299,22 @@ func buildRecentAdvisories(result *client.SearchAdvisoryResult, q digestQuery) r
 	response.Notes = []string{digestNote}
 
 	if response.Total > response.Returned {
-		response.Notes = append(response.Notes, digestPartialNote)
+		// Mutually exclusive, not merely different in emphasis: digestPartialNote tells the
+		// caller to report total, which is right when the shortfall is paging and overstates
+		// the answer when a post-slice filter caused it.
+		if q.postSliceFiltered() {
+			response.Notes = append(response.Notes, digestFilteredTotalNote)
+		} else {
+			response.Notes = append(response.Notes, digestPartialNote)
+		}
+		// Naming the route is half the point of saying the set is partial, and it is owed
+		// to both clauses above: one says total overstates the answer and the other that it
+		// counts beyond this page, and neither on its own tells the caller how to reach the
+		// rest. Gated as search_advisory and the index tools gate it — not once a walk is
+		// under way, since the caller is already holding the cursor.
+		if response.NextCursor == "" && q.Cursor == "" {
+			response.Notes = append(response.Notes, cursorRouteNote)
+		}
 	}
 	// A single feed dominating usually means it is mid-bulk-update, which makes the
 	// page look like the whole story when it is one source's churn.

--- a/internal/server/list_recent_advisories_test.go
+++ b/internal/server/list_recent_advisories_test.go
@@ -205,7 +205,7 @@ func TestListRecentAdvisories_SerializesTheDigest(t *testing.T) {
 
 	var payload recentAdvisoriesResponse
 	require.NoError(t, json.Unmarshal([]byte(text.Text), &payload))
-	assert.Equal(t, int32(408894), payload.Total)
+	assert.Equal(t, 408894, payload.Total)
 	assert.Equal(t, 1, payload.Returned)
 	assert.Equal(t, "next", payload.NextCursor)
 	require.Len(t, payload.Data, 1)

--- a/internal/server/list_recent_advisories_test.go
+++ b/internal/server/list_recent_advisories_test.go
@@ -326,3 +326,134 @@ func TestBuildRecentAdvisories_FlagsAPageWithNoProse(t *testing.T) {
 		assert.NotContains(t, strings.Join(got.Notes, " "), "identity and timing only")
 	})
 }
+
+// TestBuildRecentAdvisories_PostSliceFilterNotes pins which explanation a shortfall earns,
+// the same distinction TestSearchAdvisoryPostSliceFilterNotes pins for the other tool on
+// /v4/advisory. Both tools send vendor and product to an endpoint that applies them after
+// slicing the page, so both have to tell the caller which kind of shortfall this is.
+//
+// The live shape this guards: vendor=Ivanti&updatedAfter=now-30d&limit=25 returns 23 rows
+// against a total of 142. digestPartialNote would have the caller report 142 Ivanti
+// advisories for the window where 23 is what survived the filter.
+func TestBuildRecentAdvisories_PostSliceFilterNotes(t *testing.T) {
+	rows := []json.RawMessage{advisoryRaw("CVE-1", "a", "ghsa", "", "", "", "")}
+
+	for _, tt := range []struct {
+		name  string
+		query digestQuery
+		want  string
+		not   string
+	}{
+		{
+			name:  "a vendor filter earns the upper-bound explanation",
+			query: digestQuery{UpdatedAfter: "now-30d", Vendor: "Ivanti"},
+			want:  digestFilteredTotalNote, not: digestPartialNote,
+		},
+		{
+			name:  "so does a product filter",
+			query: digestQuery{UpdatedAfter: "now-30d", Product: "Lodash"},
+			want:  digestFilteredTotalNote, not: digestPartialNote,
+		},
+		{
+			// No post-slice filter, so the shortfall really is paging and total really
+			// is the count of what matched the window.
+			name:  "a window-only query is genuinely on page one of many",
+			query: digestQuery{UpdatedAfter: "now-30d"},
+			want:  digestPartialNote, not: digestFilteredTotalNote,
+		},
+		{
+			name:  "a feed-scoped query likewise",
+			query: digestQuery{UpdatedAfter: "now-30d", Name: "ghsa"},
+			want:  digestPartialNote, not: digestFilteredTotalNote,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRecentAdvisories(
+				&client.SearchAdvisoryResult{Data: rows, Total: 142}, tt.query)
+
+			assert.Contains(t, got.Notes, tt.want)
+			assert.NotContains(t, got.Notes, tt.not)
+		})
+	}
+}
+
+// The handler must hand the filters it sent to the response builder, not just to the API.
+// Forwarding them upstream while withholding them from the builder is exactly how the
+// pre-filter total came to be described as the window count.
+func TestListRecentAdvisories_FiltersReachTheNotes(t *testing.T) {
+	got, _, err := MakeListRecentAdvisoriesHandler(&mockClient{
+		searchAdvisoryFn: func(_ context.Context, _ client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+			return &client.SearchAdvisoryResult{
+				Data:  []json.RawMessage{advisoryRaw("CVE-1", "a", "ghsa", "", "", "", "")},
+				Total: 142,
+			}, nil
+		},
+	})(context.Background(), nil, listRecentAdvisoriesArgs{Vendor: "Ivanti", UpdatedAfter: "now-30d"})
+	require.NoError(t, err)
+
+	var response recentAdvisoriesResponse
+	require.NoError(t, json.Unmarshal([]byte(got.Content[0].(*mcp.TextContent).Text), &response))
+
+	assert.Equal(t, 142, response.Total)
+	assert.Equal(t, 1, response.Returned)
+	assert.Contains(t, response.Notes, digestFilteredTotalNote)
+	assert.NotContains(t, response.Notes, digestPartialNote)
+}
+
+// TestBuildRecentAdvisories_NamesTheCursorRoute is the digest counterpart to
+// TestSearchAdvisoryNamesTheCursorRoute. This tool paginates by cursor but only issues one
+// when asked, so a partial page that carries no next_cursor left the caller told the set was
+// incomplete and given no way to ask for the rest — on either partial clause.
+func TestBuildRecentAdvisories_NamesTheCursorRoute(t *testing.T) {
+	rows := []json.RawMessage{advisoryRaw("CVE-1", "a", "ghsa", "", "", "", "")}
+	partial := func(q digestQuery, nextCursor string) recentAdvisoriesResponse {
+		return buildRecentAdvisories(
+			&client.SearchAdvisoryResult{Data: rows, Total: 142, NextCursor: nextCursor}, q)
+	}
+
+	t.Run("named on a paging shortfall", func(t *testing.T) {
+		got := partial(digestQuery{UpdatedAfter: "now-30d"}, "")
+
+		assert.Contains(t, got.Notes, digestPartialNote)
+		assert.Contains(t, got.Notes, cursorRouteNote)
+	})
+
+	// The filtered-total clause says total overstates the answer, which is a reason to fetch
+	// the remaining pages rather than a reason not to.
+	t.Run("named alongside the filtered-total clause", func(t *testing.T) {
+		got := partial(digestQuery{UpdatedAfter: "now-30d", Vendor: "Ivanti"}, "")
+
+		assert.Contains(t, got.Notes, digestFilteredTotalNote)
+		assert.Contains(t, got.Notes, cursorRouteNote)
+	})
+
+	t.Run("withheld once the caller holds a cursor", func(t *testing.T) {
+		got := partial(digestQuery{UpdatedAfter: "now-30d", Cursor: "c"}, "")
+
+		assert.Contains(t, got.Notes, digestPartialNote)
+		assert.NotContains(t, got.Notes, cursorRouteNote,
+			"repeating the route on every page of a walk is noise in a budgeted response")
+	})
+
+	t.Run("withheld when the response already carries one", func(t *testing.T) {
+		got := partial(digestQuery{UpdatedAfter: "now-30d"}, "next")
+
+		assert.NotContains(t, got.Notes, cursorRouteNote, "next_cursor is the route")
+	})
+
+	// Forwarding the cursor upstream while withholding it from the builder is the same
+	// wiring mistake that let a pre-filter total be described as the window count.
+	t.Run("the handler hands the cursor to the builder", func(t *testing.T) {
+		got, _, err := MakeListRecentAdvisoriesHandler(&mockClient{
+			searchAdvisoryFn: func(_ context.Context, _ client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				return &client.SearchAdvisoryResult{Data: rows, Total: 142}, nil
+			},
+		})(context.Background(), nil, listRecentAdvisoriesArgs{UpdatedAfter: "now-30d", Cursor: "c"})
+		require.NoError(t, err)
+
+		var response recentAdvisoriesResponse
+		require.NoError(t, json.Unmarshal([]byte(got.Content[0].(*mcp.TextContent).Text), &response))
+
+		assert.NotContains(t, response.Notes, cursorRouteNote)
+	})
+}

--- a/internal/server/live_test.go
+++ b/internal/server/live_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -151,4 +152,89 @@ func TestLiveLog4ShellIsUsable(t *testing.T) {
 			"only arrays that were actually shortened are reported")
 	}
 	fmt.Fprintf(os.Stderr, "note: %s\n", report.Note)
+}
+
+// TestLiveSilentFilterDropIsReported is the claim #3312 turns on, and it needs the real API
+// because the whole mechanism rests on a field the API returns: _meta.parameters.
+//
+// This test is partly a canary on upstream behaviour. It asserts that target-intel does not
+// accept threat_actor and that the API answers HTTP 200 with an unfiltered total rather than
+// rejecting the query. If #3306 lands and unknown parameters start returning 400, the
+// handler will error and this test will fail — that is the intended signal, not a regression
+// here. The detection code becomes unnecessary at that point and should be removed.
+func TestLiveSilentFilterDropIsReported(t *testing.T) {
+	token := os.Getenv("VULNCHECK_API_TOKEN")
+	if token == "" {
+		t.Skip("VULNCHECK_API_TOKEN not set")
+	}
+	handler := MakeSearchIndexHandler(client.New(token, "live-test"))
+
+	read := func(t *testing.T, args searchIndexArgs) (payload string, total int, dropped string) {
+		t.Helper()
+		result, _, err := handler(context.Background(), nil, args)
+		require.NoError(t, err)
+		payload = payloadText(t, result)
+		var got struct {
+			Total int      `json:"total"`
+			Notes []string `json:"notes"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(payload), &got))
+		for _, n := range got.Notes {
+			if strings.HasPrefix(n, "FILTERS NOT APPLIED") {
+				return payload, got.Total, n
+			}
+		}
+		return payload, got.Total, ""
+	}
+
+	// target-intel does not list threat_actor, so the filter is discarded upstream and the
+	// total is the whole index. This is the query that reads as "hosts linked to this
+	// actor" and answers with every host VulnCheck has ever seen.
+	payload, filteredTotal, dropped := read(t, searchIndexArgs{
+		Index: targetIntelIndex, ThreatActor: "UNC2630", Limit: 1,
+	})
+	require.NotEmpty(t, dropped, "an unsupported filter must be reported, not silently ignored")
+	assert.Contains(t, dropped, "threat_actor", "the note must name the filter that did nothing")
+
+	_, baselineTotal, _ := read(t, searchIndexArgs{Index: targetIntelIndex, Limit: 1})
+	assert.Equal(t, baselineTotal, filteredTotal,
+		"the filtered total equals the unfiltered one, which is what makes this dangerous")
+
+	// The warning leads the notes, and on the direct-marshal path the whole envelope
+	// precedes the rows.
+	assert.Less(t, strings.Index(payload, `"notes"`), strings.Index(payload, `"data"`),
+		"the envelope precedes the rows when the struct is marshalled directly")
+
+	// It survives the shortening path too, which is the one that matters most here: an
+	// ignored filter returns an unfiltered result, and unfiltered results are what
+	// overflow the budget.
+	capped, _, cappedDrop := read(t, searchIndexArgs{
+		Index: targetIntelIndex, ThreatActor: "UNC2630", Limit: maxProductLimit,
+	})
+	require.NotEmpty(t, cappedDrop, "the warning must survive an over-budget response")
+	require.Contains(t, capped, `"response_size"`, "200 target-intel rows must exceed the budget")
+
+	// A filter the index does accept must draw no complaint, or the note is noise.
+	_, acceptedTotal, acceptedDrop := read(t, searchIndexArgs{
+		Index: "vulncheck-nvd2", ThreatActor: "UNC2630", Limit: 1,
+	})
+	assert.Empty(t, acceptedDrop, "vulncheck-nvd2 accepts threat_actor")
+	assert.Positive(t, acceptedTotal)
+	assert.Less(t, acceptedTotal, 1_000, "and actually applied it")
+
+	// Controls are not filters. Sorting must not look like a dropped filter, or every
+	// sorted query carries a false warning.
+	_, _, sortedDrop := read(t, searchIndexArgs{
+		Index: "vulncheck-nvd2", Sort: "_timestamp", Order: "desc", Limit: 1,
+	})
+	assert.Empty(t, sortedDrop, "sort and order are controls, not filters")
+
+	// A genuine no-match publishes no parameter list, so the guard must hold: an ignored
+	// filter can only widen a result, so an empty answer cannot be hiding a narrower one.
+	_, emptyTotal, emptyDrop := read(t, searchIndexArgs{
+		Index: "vulncheck-nvd2", ThreatActor: "NOSUCHACTOR", Limit: 1,
+	})
+	assert.Zero(t, emptyTotal)
+	assert.Empty(t, emptyDrop,
+		"no parameter list means unknown, not everything-dropped")
 }

--- a/internal/server/product_index.go
+++ b/internal/server/product_index.go
@@ -25,17 +25,176 @@ const offsetCeiling = 10_000
 const maxProductLimit = 200
 
 const (
+	// populationNote adds what is true only of the host- and event-oriented indices,
+	// where a page is a sample of a population rather than a slice of an enumeration.
+	//
+	// It stops at "sample" because partialSetNote, which always accompanies it, already
+	// says the rows are partial and that total is the number to report. "Sample" is the
+	// part that is not redundant: a page implies an enumeration you could walk to the
+	// end, and these indices do not have one.
 	populationNote = "this index describes a population of hosts or events rather than one record " +
-		"per CVE, so these rows are a sample and total is the size of the whole matching set — " +
-		"report total rather than counting the rows returned"
+		"per CVE, so these rows are a sample of it"
 
-	ceilingNote = "total exceeds the number of records reachable by paging (page x limit is capped " +
-		"at 10000 upstream); for the full set use a backup of this index rather than paginating"
+	// ceilingNote names both routes and not the mechanism.
+	//
+	// Both, because only one of them is obvious and it is the expensive one: sending a
+	// caller to fetch a whole backup when the tool in its hand can walk the set by cursor
+	// is a needlessly large answer to a small problem. The upstream error names both for
+	// the same reason.
+	//
+	// Not the mechanism, because upstream the cap is on page x limit and no tool here
+	// sends a page — a caller cannot reach that error from this server, and explaining it
+	// only invites them to look for a parameter that does not exist.
+	ceilingNote = "total exceeds what a single sequence of pages can reach (10000 records " +
+		"upstream). Cursor pagination is not subject to that limit: pass start_cursor on the " +
+		"first call, then next_cursor as cursor. For the whole set at once, use a backup of " +
+		"this index"
 
-	emptyPageNote = "records match this query but none was returned on this page: the API applies the " +
-		"filter to a page after slicing it, so a small limit can yield nothing while total is " +
-		"non-zero. This is not an absence of data — retry with a larger limit"
+	// droppedFilterNote names filters the index does not accept.
+	//
+	// It leads with the consequence, not the mechanism. The API ignores an unsupported
+	// parameter and answers HTTP 200 with an unfiltered result and a total that looks
+	// entirely plausible, so this note is the only thing standing between a caller and
+	// reporting an unnarrowed set as a filtered one — which, on a security question, is
+	// how "these hosts are linked to this actor" gets said about every host.
+	droppedFilterNote = "FILTERS NOT APPLIED: this index does not accept %s. The API ignores an " +
+		"unsupported filter rather than rejecting it, so these rows and total are NOT narrowed by " +
+		"it and must not be reported as though they were. Call describe_index for the filters this " +
+		"index accepts"
+
+	// cursorExhaustedNote covers the other reason a page comes back empty. emptyPageNote
+	// tells the caller to retry with a larger limit, which is sound advice for a page the
+	// filter emptied and useless advice at the end of a cursor walk — there is nothing
+	// left to page to, at any limit.
+	cursorExhaustedNote = "the cursor walk is complete: this page is empty and there is no next " +
+		"cursor, so every record reachable this way has already been returned. total counts what " +
+		"matched upstream, not what remains — a larger limit will not produce more"
+
+	// emptyPageNote comes in two endings because the diagnosis is shared and the remedy is
+	// not. The cause is the same either way — the API filters a page after slicing it — but
+	// telling a caller mid-walk to enlarge its limit is wrong, not merely unhelpful: the
+	// route onward is the cursor already sitting in the response it is reading.
+	emptyPageDiagnosis = "records match this query but none was returned on this page: the API " +
+		"applies the filter to a page after slicing it, so a small limit can yield nothing while " +
+		"total is non-zero. This is not an absence of data — "
+
+	emptyPageNote = emptyPageDiagnosis + "retry with a larger limit"
+
+	emptyPageMidWalkNote = emptyPageDiagnosis + "this response carries a next_cursor, so pass it " +
+		"back as cursor to continue the walk"
 )
+
+// populationIndexPrefixes are the indices whose rows are hosts or events rather than one
+// record per CVE.
+//
+// It is not dedicatedTools, which is the near-identical set plus `exploits`. That index is
+// one row per CVE carrying its exploit entries — see defaultCuratedExploitsLimit — so
+// calling it a population of hosts or events would be false, and it was being told exactly
+// that before this set existed.
+//
+// It is also a deliberate under-approximation of the whole catalogue: the API publishes 506
+// indices and several outside this list are many-rows-per-CVE. A miss costs one absent
+// clause rather than a wrong one, because partialSetNote still goes out and still says to
+// report total. A small certain set beats an exhaustive guess.
+var populationIndexPrefixes = []string{targetIntelIndex, ipIntelPrefix, canaryPrefix}
+
+// isPopulationIndex reports whether an index describes a population of hosts or events.
+// Prefixes rather than exact names, because the windowed families resolve to
+// "ipintel-3d", "vulncheck-canaries-all" and so on.
+func isPopulationIndex(index string) bool {
+	for _, prefix := range populationIndexPrefixes {
+		if strings.HasPrefix(index, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// droppedFilterNoteFor names the filters this query sent that the index does not accept, or
+// returns "" when none were dropped.
+//
+// The comparison is free: /v3/index returns the index's own parameter list inline with every
+// query, and the client records which filters it actually put on the request, so neither
+// side needs a second call or a hardcoded table.
+//
+// Nothing is claimed when the index published no list, which happens on a zero-row response
+// from some indices. That exemption is safe rather than merely convenient: a dropped filter
+// is monotonic — an ignored filter is not applied, so the result can only be the same size
+// or wider — so a response with no rows cannot be concealing a narrower answer than the
+// caller already sees. A filter the index lists but does not honour is invisible from here;
+// that one closes upstream, by rejecting unknown parameters instead of ignoring them.
+func droppedFilterNoteFor(result *client.IndexQueryResult) string {
+	// An empty list means the index did not publish one, which is not the same as
+	// accepting nothing. The client drops blank names when parsing, so this is the only
+	// check needed.
+	if len(result.FiltersAccepted) == 0 {
+		return ""
+	}
+
+	var dropped []string
+	for _, sent := range result.FiltersSent {
+		if !slices.Contains(result.FiltersAccepted, sent) {
+			dropped = append(dropped, sent)
+		}
+	}
+	if len(dropped) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(droppedFilterNote, strings.Join(dropped, ", "))
+}
+
+// indexNotes reports what the /v3/index endpoint did to a query.
+//
+// It is shared by the product tools and search_index because they call the same endpoint
+// through the same client function and receive the same envelope. search_index carried none
+// of these notes until now, despite being the tool most exposed to the empty-page trap: its
+// limit defaults to 1, which is where a filter applied after slicing is most likely to
+// yield nothing from a non-zero total.
+func indexNotes(index string, result *client.IndexQueryResult) []string {
+	returned, total := len(result.Data), result.Total
+
+	var notes []string
+
+	// First, because it is the only one that says the answer is wrong rather than
+	// incomplete: everything below describes a partial result, this describes a result
+	// that does not mean what it appears to.
+	if dropped := droppedFilterNoteFor(result); dropped != "" {
+		notes = append(notes, dropped)
+	}
+
+	// An empty page with a non-zero total is not an absence of data, and must not be
+	// reported as a sample: the filter is applied to a page after it is sliced, so a
+	// small limit can legitimately yield nothing. Saying so is the difference between
+	// "nothing matches" and "ask again for more".
+	switch {
+	case returned == 0 && total > 0 && result.CursorContinuation && result.NextCursor == "":
+		notes = append(notes, cursorExhaustedNote)
+	case returned == 0 && total > 0 && result.NextCursor != "":
+		notes = append(notes, emptyPageMidWalkNote)
+	case returned == 0 && total > 0:
+		notes = append(notes, emptyPageNote)
+	case total > returned:
+		notes = append(notes, partialSetNote)
+		if isPopulationIndex(index) {
+			notes = append(notes, populationNote)
+		}
+		// Naming the route is half the point of saying the set is partial. Skipped
+		// once a walk is under way, since the caller is holding the cursor, and above
+		// the offset ceiling, where ceilingNote names this route and the backup both.
+		if result.NextCursor == "" && !result.CursorContinuation && total <= offsetCeiling {
+			notes = append(notes, cursorRouteNote)
+		}
+	}
+
+	// Not on a walk already in progress: the caller is holding the cursor this would tell
+	// them to use, and repeating it on every page is noise in a budgeted response.
+	if total > offsetCeiling && !result.CursorContinuation {
+		notes = append(notes, ceilingNote)
+	}
+
+	return notes
+}
 
 // windowedIndex resolves a window token to a concrete index name.
 func windowedIndex(prefix, window string) (string, error) {
@@ -48,18 +207,16 @@ func windowedIndex(prefix, window string) (string, error) {
 	return prefix + "-" + window, nil
 }
 
-// productResponse is the shape the three product tools return.
+// productResponse is the shape the four product tools return — search_target_intel,
+// search_ip_intel, search_canaries and search_curated_exploits.
 //
 // It is a new contract rather than a reshaping of an existing one: these tools do
 // not claim to hand back a raw /v3/index envelope, so they are free to report what
 // they did. The rows in Data are still passed through verbatim.
 type productResponse struct {
-	Index      string            `json:"index"`
-	Data       []json.RawMessage `json:"data"`
-	Returned   int               `json:"returned"`
-	Total      int               `json:"total"`
-	NextCursor string            `json:"next_cursor,omitempty"`
-	Notes      []string          `json:"notes,omitempty"`
+	envelope
+	Index string            `json:"index"`
+	Data  []json.RawMessage `json:"data"`
 }
 
 // productLimit clamps a requested row count to the upstream maximum, falling back to
@@ -81,25 +238,11 @@ func productLimit(requested, fallback int) int {
 // what the API did, not what MCP did to fit it.
 func newProductResponse(index string, result *client.IndexQueryResult) productResponse {
 	response := productResponse{
-		Index:      index,
-		Data:       result.Data,
-		Total:      result.Total,
-		NextCursor: result.NextCursor,
-		Returned:   len(result.Data),
+		envelope: newEnvelope(len(result.Data), result.Total, result.NextCursor),
+		Index:    index,
+		Data:     result.Data,
 	}
-	// An empty page with a non-zero total is not the same as no data, and must not be
-	// reported as a sample: the filter is applied to a page after it is sliced, so a
-	// small limit can legitimately yield nothing. Saying so is the difference between
-	// "nothing matches" and "ask again for more".
-	switch {
-	case response.Returned == 0 && response.Total > 0:
-		response.Notes = append(response.Notes, emptyPageNote)
-	case response.Total > response.Returned:
-		response.Notes = append(response.Notes, populationNote)
-	}
-	if response.Total > offsetCeiling {
-		response.Notes = append(response.Notes, ceilingNote)
-	}
+	response.Notes = indexNotes(index, result)
 
 	return response
 }

--- a/internal/server/product_index_test.go
+++ b/internal/server/product_index_test.go
@@ -119,8 +119,14 @@ func TestNewProductResponse_WarnsWhenTotalExceedsWhatPagingCanReach(t *testing.T
 		Data:  []json.RawMessage{json.RawMessage(`{"ip":"203.0.113.1"}`)},
 		Total: offsetCeiling + 1,
 	})
-	assert.Contains(t, strings.Join(beyond.Notes, " "), "backup",
+	joined := strings.Join(beyond.Notes, " ")
+	assert.Contains(t, joined, "backup",
 		"beyond the paging ceiling the caller must be pointed at the backup")
+	// The cheaper of the two routes, and the one a caller will not guess: cursor
+	// pagination is not subject to the page x limit cap, so naming only the backup sends
+	// callers to fetch a whole index when the tool they are holding can walk it.
+	assert.Contains(t, joined, "start_cursor",
+		"the cursor is a route past the ceiling and must be named alongside the backup")
 
 	within := newProductResponse("target-intel", &client.IndexQueryResult{
 		Data:  []json.RawMessage{json.RawMessage(`{"ip":"203.0.113.1"}`)},
@@ -407,5 +413,208 @@ func TestSearchTargetIntelArgs_DoesNotSuggestCombinedClassifications(t *testing.
 	if before, _, found := strings.Cut(schema, "c2:cobalt-strike"); found {
 		assert.Contains(t, before, "Do not",
 			"if the combined form is mentioned it must be as a warning")
+	}
+}
+
+// TestIndexNotes pins which notes each shape of /v3/index result earns.
+//
+// The distinction that matters is between the universally-true half and the index-specific
+// half: sending the specific half where it is false is worse than omitting it, because a
+// caller told that `exploits` "describes a population of hosts or events" will read one row
+// per CVE as a sample of hosts. The dropped-filter warning is not here — it travels in
+// notes as its first entry, and TestDroppedFilterNote covers it.
+func TestIndexNotes(t *testing.T) {
+	rows := func(n int) []json.RawMessage {
+		out := make([]json.RawMessage, n)
+		for i := range out {
+			out[i] = json.RawMessage(`{}`)
+		}
+		return out
+	}
+
+	tests := []struct {
+		name     string
+		index    string
+		returned int
+		tot      int
+		cursor   string
+		resumed  bool
+
+		want     []string
+		wantNone []string
+	}{
+		{
+			name: "complete set earns nothing",
+			// Every row matched is present, so there is nothing to warn about.
+			index: "vulncheck-nvd2", returned: 5, tot: 5,
+			wantNone: []string{partialSetNote, populationNote, emptyPageNote, ceilingNote},
+		},
+		{
+			name: "empty page mid-walk points at the cursor, not a bigger limit",
+			// Same diagnosis, different remedy: enlarging the limit is the wrong move
+			// when the route onward is in the response the caller is already reading.
+			index: "vulncheck-nvd2", returned: 0, tot: 40, cursor: "more", resumed: true,
+			want:     []string{emptyPageMidWalkNote},
+			wantNone: []string{emptyPageNote, partialSetNote, populationNote, cursorExhaustedNote},
+		},
+		{
+			name: "an empty page mid-walk on a first call still gets the cursor advice",
+			// start_cursor was passed but no page has been consumed yet; the cursor in
+			// this response is still the route onward.
+			index: "vulncheck-nvd2", returned: 0, tot: 40, cursor: "more", resumed: false,
+			want:     []string{emptyPageMidWalkNote},
+			wantNone: []string{emptyPageNote},
+		},
+		{
+			name: "empty page at the end of a cursor walk says the walk is over",
+			// The filter-after-slicing advice is wrong here: a larger limit cannot
+			// help, because there is nothing left to page to.
+			index: "vulncheck-nvd2", returned: 0, tot: 40, cursor: "", resumed: true,
+			want:     []string{cursorExhaustedNote},
+			wantNone: []string{emptyPageNote},
+		},
+		{
+			name: "an empty page with no cursor in play keeps the retry advice",
+			// A plain query returns an empty next_cursor too, so without
+			// CursorContinuation this is indistinguishable from a finished walk.
+			index: "vulncheck-nvd2", returned: 0, tot: 40, cursor: "", resumed: false,
+			want:     []string{emptyPageNote},
+			wantNone: []string{cursorExhaustedNote},
+		},
+		{
+			name:  "a per-CVE index gets the universal half only",
+			index: "vulncheck-nvd2", returned: 1, tot: 400,
+			want:     []string{partialSetNote},
+			wantNone: []string{populationNote},
+		},
+		{
+			name:  "a host index gets both halves",
+			index: "target-intel", returned: 10, tot: 9_000,
+			want: []string{partialSetNote, populationNote},
+		},
+		{
+			name:  "windowed families match by prefix",
+			index: "ipintel-30d", returned: 10, tot: 9_000,
+			want: []string{partialSetNote, populationNote},
+		},
+		{
+			name: "canaries match by prefix, including the unwindowed index",
+			// canaryIndex("all") resolves to the bare prefix, so this is the name the
+			// tool actually queries — "vulncheck-canaries-all" is not an index.
+			index: "vulncheck-canaries", returned: 20, tot: 9_000,
+			want: []string{partialSetNote, populationNote},
+		},
+		{
+			name: "exploits is one row per CVE, not a population",
+			// It sits in dedicatedTools alongside the host indices, which is why
+			// gating on that map would tell this caller something false.
+			index: "exploits", returned: 25, tot: 900,
+			want:     []string{partialSetNote},
+			wantNone: []string{populationNote},
+		},
+		{
+			name:  "a total beyond the offset ceiling names both routes",
+			index: "vulncheck-nvd2", returned: 1, tot: offsetCeiling + 1,
+			want: []string{partialSetNote, ceilingNote},
+		},
+		{
+			name: "the ceiling note is not repeated to a caller already walking",
+			// It tells the caller to use the cursor they are holding, on every page.
+			index: "vulncheck-nvd2", returned: 1, tot: offsetCeiling + 1,
+			cursor: "more", resumed: true,
+			want:     []string{partialSetNote},
+			wantNone: []string{ceilingNote},
+		},
+		{
+			name: "a partial set names the route to the rest",
+			// Saying "report 5194" without saying how to reach the other 5192 is half
+			// an answer, and this tool takes start_cursor.
+			index: "vulncheck-nvd2", returned: 2, tot: 5_194,
+			want: []string{partialSetNote, cursorRouteNote},
+		},
+		{
+			name:  "the route is not repeated to a caller already walking",
+			index: "vulncheck-nvd2", returned: 2, tot: 5_194, cursor: "more", resumed: true,
+			want:     []string{partialSetNote},
+			wantNone: []string{cursorRouteNote},
+		},
+		{
+			name:  "above the ceiling, ceilingNote names both routes instead",
+			index: "vulncheck-nvd2", returned: 1, tot: offsetCeiling + 1,
+			want:     []string{partialSetNote, ceilingNote},
+			wantNone: []string{cursorRouteNote},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notes := indexNotes(tt.index, &client.IndexQueryResult{
+				Data:               rows(tt.returned),
+				Total:              tt.tot,
+				NextCursor:         tt.cursor,
+				CursorContinuation: tt.resumed,
+			})
+			for _, want := range tt.want {
+				assert.Contains(t, notes, want)
+			}
+			for _, unwanted := range tt.wantNone {
+				assert.NotContains(t, notes, unwanted)
+			}
+		})
+	}
+}
+
+// TestDroppedFilterNote covers the one note that says the answer is wrong rather than
+// partial: a filter the index does not accept, which the API discards while returning
+// HTTP 200 and an unfiltered total.
+func TestDroppedFilterNote(t *testing.T) {
+	tests := []struct {
+		name     string
+		sent     []string
+		accepted []string
+		want     []string
+		wantNone bool
+	}{
+		{
+			name: "an accepted filter draws no complaint",
+			sent: []string{"cve"}, accepted: []string{"cve", "threat_actor"},
+			wantNone: true,
+		},
+		{
+			name: "a filter the index does not accept is named",
+			// The real case: target-intel accepts neither threat_actor nor
+			// ransomware, and answers 200 with the whole index.
+			sent: []string{"cve", "threat_actor"}, accepted: []string{"asn", "country", "cve"},
+			want: []string{"FILTERS NOT APPLIED", "threat_actor"},
+		},
+		{
+			name: "several dropped filters are all named",
+			sent: []string{"botnet", "ransomware"}, accepted: []string{"cve"},
+			want: []string{"botnet, ransomware"},
+		},
+		{
+			name: "no published parameter list means no claim either way",
+			// Some indices omit the list on a zero-row response. An absent list is
+			// "unknown", not "accepts nothing" — asserting a drop here would fire on
+			// a genuine no-match.
+			sent: []string{"cve", "threat_actor"}, accepted: nil,
+			wantNone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			note := droppedFilterNoteFor(&client.IndexQueryResult{
+				FiltersSent:     tt.sent,
+				FiltersAccepted: tt.accepted,
+			})
+			if tt.wantNone {
+				assert.Empty(t, note)
+				return
+			}
+			for _, want := range tt.want {
+				assert.Contains(t, note, want)
+			}
+		})
 	}
 }

--- a/internal/server/search_advisory.go
+++ b/internal/server/search_advisory.go
@@ -75,9 +75,11 @@ const (
 		"the vendor's advisories are returned instead; product strings are CNA prose and are matched " +
 		"exactly, so pick one from products_found rather than guessing"
 
-	totalMismatchNote = "total counts documents matched before the API's exact vendor/product filter " +
-		"runs, so it is an upper bound on what any spelling can return rather than a count of " +
-		"withheld records"
+	totalMismatchNote = "total counts documents matched before the API's exact vendor, product and " +
+		"version filters run, so it is an upper bound on what those filters can return rather than " +
+		"a count of withheld records — do NOT report it as the number of matching advisories. The " +
+		"rows in this response are the ones that survived; if next_cursor is present, further pages " +
+		"may add more"
 
 	trimmedNote = "more records were found than the requested limit; raise limit to see the rest"
 
@@ -182,20 +184,42 @@ func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdviso
 		// Removing this line fails TestSearchAdvisoryLimitContract.
 		response.Returned = len(response.Data)
 		if response.Total > response.Returned {
-			// partialSetNote is always true here. The other two explain the API's
-			// exact vendor/product filter and are true only when one was used — a
-			// query filtered by feed name alone is simply on page one of many, and
-			// sending it the vendor explanation points at a problem it does not have.
-			// The two are not exclusive: a vendor query can be both mismatched and
-			// genuinely paginated.
-			response.Notes = append(response.Notes, partialSetNote)
-			if query.Vendor != "" || query.Product != "" {
-				response.Notes = append(response.Notes, totalMismatchNote, slugNote)
+			// partialSetNote and totalMismatchNote are mutually exclusive, not merely
+			// redundant. partialSetNote instructs the caller to report total rather
+			// than counting the rows, which is right when the shortfall is paging and
+			// wrong when it is a filter the API applied after slicing the page: there
+			// total is an upper bound on what the filter could return, and reporting
+			// it overstates the answer. A version query is the clearest case — 1 row
+			// survives against a total of 11 — and "report total" would turn one
+			// affected advisory into eleven.
+			if postSliceFiltered(query) {
+				response.Notes = append(response.Notes, totalMismatchNote)
+				// Vendor-spelling advice, so it is gated more narrowly than the
+				// note above: sending it to a query filtered only by version
+				// points at a problem that query does not have.
+				if query.Vendor != "" || query.Product != "" {
+					response.Notes = append(response.Notes, slugNote)
+				}
+			} else {
+				response.Notes = append(response.Notes, partialSetNote)
 			}
 		}
 
 		return capResult(response)
 	}
+}
+
+// postSliceFiltered reports whether the query used a filter the API applies after slicing a
+// page, which is what makes total an upper bound rather than a count of withheld records.
+//
+// Vendor and product are compared exactly and case-sensitively downstream of the page, which
+// is the defect #46 was about. Version is worse: it is not part of the upstream search query
+// at all — /v4/advisory skips it deliberately ("version checks need to happen after data
+// aggregated before return") and evaluates it against the assembled records on the way out.
+// So it narrows the rows and never touches total. Verified live: package_name=lodash returns
+// 11 rows against a total of 11, and adding any version returns 1 row against the same 11.
+func postSliceFiltered(q client.SearchAdvisoryQuery) bool {
+	return q.Vendor != "" || q.Product != "" || q.Version != ""
 }
 
 func advisoryQuery(args searchAdvisoryArgs) client.SearchAdvisoryQuery {

--- a/internal/server/search_advisory.go
+++ b/internal/server/search_advisory.go
@@ -202,6 +202,16 @@ func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdviso
 				}
 			} else {
 				response.Notes = append(response.Notes, partialSetNote)
+				// Naming the set partial without naming the route leaves the caller
+				// holding neither a next_cursor nor a way to ask for one, which is the
+				// gap search_cve and the index tools already close. Gated the same way:
+				// not once a walk is under way, since the caller holds the cursor.
+				//
+				// Unreachable from the widening path, which contradicts this by design —
+				// widening requires a vendor, and a vendor takes the branch above.
+				if response.NextCursor == "" && query.Cursor == "" {
+					response.Notes = append(response.Notes, cursorRouteNote)
+				}
 			}
 		}
 

--- a/internal/server/search_advisory.go
+++ b/internal/server/search_advisory.go
@@ -118,17 +118,37 @@ var SearchAdvisoryTool = &mcp.Tool{
 	},
 }
 
-// searchAdvisoryResponse wraps the client result so the handler can explain, in
-// band, when it widened the query and why the API's own total may exceed the rows
-// returned. Every added field is omitempty, so an un-widened response keeps the
-// wire shape callers already depend on.
+// searchAdvisoryResponse explains, in band, when the handler widened the query and why
+// the API's own total may exceed the rows returned.
+//
+// The vendor and product fields are specific to this tool: it is the only one that retries
+// alternative capitalisations and drops an unmatchable product filter, so it is the only
+// one with a fan-out to account for. They stay here rather than moving into envelope.
+//
+// Data, total and next_cursor are declared directly rather than inherited by embedding
+// *client.SearchAdvisoryResult, which is how this type used to get them. Keeping that
+// embedding would have put `total` and `next_cursor` at the same depth as envelope's, and
+// encoding/json drops every conflicting name at a given depth and returns no error: both
+// fields would have silently left the wire, with nothing failing to say so.
+//
+// Returned is no longer omitempty. It previously disappeared at exactly returned == 0, the
+// one value worth reporting, and capResult's correctReturned skips absent fields, so a
+// trimmed response could not have its count corrected either.
 type searchAdvisoryResponse struct {
-	*client.SearchAdvisoryResult
-	Returned      int      `json:"returned,omitempty"`
-	VendorsTried  []string `json:"vendors_tried,omitempty"`
-	VendorsFailed []string `json:"vendors_failed,omitempty"`
-	ProductsFound []string `json:"products_found,omitempty"`
-	Notes         []string `json:"notes,omitempty"`
+	envelope
+	VendorsTried  []string          `json:"vendors_tried,omitempty"`
+	VendorsFailed []string          `json:"vendors_failed,omitempty"`
+	ProductsFound []string          `json:"products_found,omitempty"`
+	Data          []json.RawMessage `json:"data"`
+}
+
+// newAdvisoryResponse seeds a response from a client result, so the three places that
+// build one cannot disagree about how the core fields are filled.
+func newAdvisoryResponse(result *client.SearchAdvisoryResult) searchAdvisoryResponse {
+	return searchAdvisoryResponse{
+		envelope: newEnvelope(len(result.Data), int(result.Total), result.NextCursor),
+		Data:     result.Data,
+	}
 }
 
 func registerSearchAdvisory(srv *mcp.Server, vc client.Client) {
@@ -144,7 +164,7 @@ func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdviso
 			return nil, nil, fmt.Errorf("searching advisories: %w", err)
 		}
 
-		response := searchAdvisoryResponse{SearchAdvisoryResult: result}
+		response := newAdvisoryResponse(result)
 		if canWiden(query) && underDelivered(result) {
 			response = widenAdvisorySearch(ctx, vc, query, result)
 			// Widening reads larger upstream pages than the caller asked for,
@@ -157,9 +177,21 @@ func MakeSearchAdvisoryHandler(vc client.Client) mcp.ToolHandlerFor[searchAdviso
 			}
 		}
 
+		// Recomputed, not redundant: newAdvisoryResponse set this at construction, and the
+		// widening branch above may then have trimmed Data back to the caller's limit.
+		// Removing this line fails TestSearchAdvisoryLimitContract.
 		response.Returned = len(response.Data)
-		if int(response.Total) > len(response.Data) {
-			response.Notes = append(response.Notes, totalMismatchNote, slugNote)
+		if response.Total > response.Returned {
+			// partialSetNote is always true here. The other two explain the API's
+			// exact vendor/product filter and are true only when one was used — a
+			// query filtered by feed name alone is simply on page one of many, and
+			// sending it the vendor explanation points at a problem it does not have.
+			// The two are not exclusive: a vendor query can be both mismatched and
+			// genuinely paginated.
+			response.Notes = append(response.Notes, partialSetNote)
+			if query.Vendor != "" || query.Product != "" {
+				response.Notes = append(response.Notes, totalMismatchNote, slugNote)
+			}
 		}
 
 		return capResult(response)
@@ -280,12 +312,10 @@ func widenAdvisorySearch(
 		notes = append(notes, variantFailedNote)
 	}
 
-	response := searchAdvisoryResponse{
-		SearchAdvisoryResult: merged.result(),
-		VendorsTried:         tried,
-		VendorsFailed:        failed,
-		Notes:                notes,
-	}
+	response := newAdvisoryResponse(merged.result())
+	response.VendorsTried = tried
+	response.VendorsFailed = failed
+	response.Notes = notes
 	if len(response.Data) > 0 || query.Product == "" {
 		return response
 	}
@@ -336,13 +366,13 @@ func dropProductFilter(
 		notes = append(notes, variantFailedNote)
 	}
 
-	return searchAdvisoryResponse{
-		SearchAdvisoryResult: result,
-		VendorsTried:         tried,
-		VendorsFailed:        failed,
-		ProductsFound:        productNames(result.Data),
-		Notes:                notes,
-	}
+	response := newAdvisoryResponse(result)
+	response.VendorsTried = tried
+	response.VendorsFailed = failed
+	response.ProductsFound = productNames(result.Data)
+	response.Notes = notes
+
+	return response
 }
 
 // vendorCaseVariants returns the spellings to try, in a fixed order so the merged
@@ -431,7 +461,25 @@ func (m *advisoryMerge) result() *client.SearchAdvisoryResult {
 		}
 	}
 
-	return &client.SearchAdvisoryResult{Data: data, Total: m.total}
+	// Never report a total below the rows being handed over.
+	//
+	// add keeps the largest pre-filter count any single spelling reported, but the union
+	// is assembled from all of them, so in principle it can be larger than that count —
+	// leaving total < returned. That inverts the one signal the envelope is built on:
+	// total > returned means "partial", and partialSetNote tells the caller to report
+	// total rather than counting the rows in front of it.
+	//
+	// Defensive rather than observed. Against the live API the pre-filter count is orders
+	// of magnitude larger than any union (vendor "apache": total 2,265, union 8), because
+	// the coarse match appears to be case-insensitive and therefore shared between
+	// spellings, which bounds the union by it. That is an upstream property we infer, not
+	// one we control, and the envelope should not depend on it.
+	total := m.total
+	if len(data) > int(total) {
+		total = int32(len(data)) //nolint:gosec // G115: bounded by maxAdvisoryLimit per spelling
+	}
+
+	return &client.SearchAdvisoryResult{Data: data, Total: total}
 }
 
 // productNames lists the distinct product and package names present, so a caller

--- a/internal/server/search_advisory_test.go
+++ b/internal/server/search_advisory_test.go
@@ -131,7 +131,7 @@ func TestMakeSearchAdvisoryHandler(t *testing.T) {
 		clientErr  error
 		wantErr    bool
 		wantLimit  int32
-		wantTotal  int32
+		wantTotal  int
 		wantLen    int
 	}{
 		{
@@ -620,4 +620,47 @@ func TestSearchAdvisoryDeterminism(t *testing.T) {
 	b, err := json.Marshal(second)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(a), string(b))
+}
+
+// TestSearchAdvisoryTotalNeverBelowReturned pins the envelope's one load-bearing
+// comparison.
+//
+// The widened path unions rows from several vendor spellings while keeping only the largest
+// pre-filter count any one of them reported, so the union can in principle be larger than
+// that count. If it is, total lands below returned — and total is the number partialSetNote
+// tells a caller to report, so it would have them report fewer records than are in front of
+// them, with no note firing because Total > Returned is false.
+//
+// Not reproducible against the live API, where the pre-filter count dwarfs any union; the
+// mock forces the shape deliberately.
+func TestSearchAdvisoryTotalNeverBelowReturned(t *testing.T) {
+	upstreamCalls := 0
+	mock := &mockClient{
+		searchAdvisoryFn: func(_ context.Context, _ client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+			upstreamCalls++
+			// Disjoint rows per spelling, and a pre-filter count smaller than the
+			// union they add up to.
+			rows := make([]json.RawMessage, 0, 3)
+			for i := range 3 {
+				rows = append(rows, json.RawMessage(
+					fmt.Sprintf(`{"cveMetadata":{"cveId":"CVE-2024-%04d"}}`, upstreamCalls*10+i)))
+			}
+			return &client.SearchAdvisoryResult{Data: rows, Total: 4}, nil
+		},
+	}
+
+	result := runTool(t, mock, func(vc client.Client) toolCall {
+		return call(MakeSearchAdvisoryHandler(vc), searchAdvisoryArgs{Vendor: "apache", Limit: 100})
+	})
+
+	var got struct {
+		Returned int      `json:"returned"`
+		Total    int      `json:"total"`
+		Notes    []string `json:"notes"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(payloadText(t, result)), &got))
+
+	require.Greater(t, upstreamCalls, 1, "the widening path must have run for this to mean anything")
+	assert.GreaterOrEqual(t, got.Total, got.Returned,
+		"total must never be less than the rows handed over")
 }

--- a/internal/server/search_advisory_test.go
+++ b/internal/server/search_advisory_test.go
@@ -380,6 +380,67 @@ func TestSearchAdvisoryVendorFanOut(t *testing.T) {
 	})
 }
 
+// TestSearchAdvisoryPostSliceFilterNotes pins which explanation a shortfall earns.
+//
+// The two notes contradict each other by design: partialSetNote says to report total rather
+// than counting the rows, and totalMismatchNote says total is an upper bound that must not be
+// reported as the answer. Exactly one can be true of a given response, and sending
+// partialSetNote where a post-slice filter caused the shortfall is the harmful direction —
+// it turns one affected advisory into eleven.
+func TestSearchAdvisoryPostSliceFilterNotes(t *testing.T) {
+	// The live shape this guards: package_name=lodash returns 11 rows against a total of
+	// 11, and adding any version returns 1 row against that same total of 11, because
+	// /v4/advisory evaluates version after assembling the records.
+	oneOfEleven := func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+		return advisoryResult(11, advisoryRef("CVE-1")), nil
+	}
+
+	for _, tt := range []struct {
+		name string
+		args searchAdvisoryArgs
+		want string
+		not  string
+	}{
+		{
+			// The filter is applied on the way out, so the single row is the whole
+			// answer and total is the count before it ran.
+			name: "a version filter earns the upper-bound explanation",
+			args: searchAdvisoryArgs{Name: "ghsa", PackageName: "lodash", Version: "4.17.15"},
+			want: totalMismatchNote, not: partialSetNote,
+		},
+		{
+			name: "so does a vendor filter",
+			args: searchAdvisoryArgs{Name: "ghsa", Vendor: "Ivanti", Cursor: "c"},
+			want: totalMismatchNote, not: partialSetNote,
+		},
+		{
+			// No post-slice filter, so the shortfall really is paging and total
+			// really is the number to report.
+			name: "a feed-only query is genuinely on page one of many",
+			args: searchAdvisoryArgs{Name: "ghsa"},
+			want: partialSetNote, not: totalMismatchNote,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := runAdvisoryHandler(t, tt.args, oneOfEleven)
+			require.NoError(t, err)
+
+			assert.Contains(t, got.Notes, tt.want)
+			assert.NotContains(t, got.Notes, tt.not)
+		})
+	}
+
+	t.Run("version alone does not earn vendor-spelling advice", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t,
+			searchAdvisoryArgs{Name: "ghsa", PackageName: "lodash", Version: "4.17.15"},
+			oneOfEleven)
+
+		require.NoError(t, err)
+		assert.NotContains(t, got.Notes, slugNote,
+			"retrying a capitalisation cannot help a version filter")
+	})
+}
+
 func TestSearchAdvisoryProductFallback(t *testing.T) {
 	t.Run("an unmatchable product is dropped and real products listed", func(t *testing.T) {
 		got, queries, err := runAdvisoryHandler(t,

--- a/internal/server/search_advisory_test.go
+++ b/internal/server/search_advisory_test.go
@@ -725,3 +725,55 @@ func TestSearchAdvisoryTotalNeverBelowReturned(t *testing.T) {
 	assert.GreaterOrEqual(t, got.Total, got.Returned,
 		"total must never be less than the rows handed over")
 }
+
+// TestSearchAdvisoryNamesTheCursorRoute pins the route clause on a genuine paging shortfall.
+//
+// docs/tools.md tells readers that notes and next_cursor are where the route to the rest of a
+// partial set is named. This tool paginates by cursor but only issues one when asked, so a
+// first call that carries neither left the caller with no route named at all — the gap
+// search_cve and the index tools already close.
+func TestSearchAdvisoryNamesTheCursorRoute(t *testing.T) {
+	pageOfMany := func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+		return advisoryResult(3541, advisoryRef("CVE-1")), nil
+	}
+
+	t.Run("named when no walk is under way", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t, searchAdvisoryArgs{Name: "ghsa"}, pageOfMany)
+		require.NoError(t, err)
+
+		assert.Contains(t, got.Notes, partialSetNote)
+		assert.Contains(t, got.Notes, cursorRouteNote)
+	})
+
+	t.Run("withheld once the caller holds a cursor", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t, searchAdvisoryArgs{Name: "ghsa", Cursor: "c"}, pageOfMany)
+		require.NoError(t, err)
+
+		assert.Contains(t, got.Notes, partialSetNote)
+		assert.NotContains(t, got.Notes, cursorRouteNote,
+			"repeating the route on every page of a walk is noise in a budgeted response")
+	})
+
+	t.Run("withheld when the response already carries one", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t, searchAdvisoryArgs{Name: "ghsa", StartCursor: true},
+			func(client.SearchAdvisoryQuery) (*client.SearchAdvisoryResult, error) {
+				result := advisoryResult(3541, advisoryRef("CVE-1"))
+				result.NextCursor = "next"
+				return result, nil
+			})
+		require.NoError(t, err)
+
+		assert.NotContains(t, got.Notes, cursorRouteNote, "next_cursor is the route")
+	})
+
+	// The widening path appends widenedNote, which says pagination is unavailable. It must
+	// not also be told to paginate — and it cannot be, because widening needs a vendor and a
+	// vendor earns totalMismatchNote instead. Pinned so that stays true.
+	t.Run("never contradicts a widened search", func(t *testing.T) {
+		got, _, err := runAdvisoryHandler(t, searchAdvisoryArgs{Vendor: "anthropic"}, pageOfMany)
+		require.NoError(t, err)
+
+		assert.Contains(t, got.Notes, widenedNote)
+		assert.NotContains(t, got.Notes, cursorRouteNote)
+	})
+}

--- a/internal/server/search_cpe.go
+++ b/internal/server/search_cpe.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/vulncheck-oss/mcp/internal/client"
+	vulncheck "github.com/vulncheck-oss/sdk-go-v2/v2"
 )
 
 type searchCPEArgs struct {
@@ -13,16 +14,32 @@ type searchCPEArgs struct {
 	Vendor         string `json:"vendor,omitempty"          jsonschema:"CPE vendor"`
 	Product        string `json:"product,omitempty"         jsonschema:"CPE product"`
 	Version        string `json:"version,omitempty"         jsonschema:"CPE version (supports trailing wildcards, e.g. '8.0.*')"`
-	VulnerableOnly bool   `json:"vulnerable_only,omitempty" jsonschema:"When true, return only CPEs confirmed vulnerable (default false)"`
+	VulnerableOnly bool   `json:"vulnerable_only,omitempty" jsonschema:"When true, each CPE lists only the CVEs for which it is a vulnerable configuration, rather than every CVE referencing it. This does NOT reduce the set of CPEs returned — the row count is the same either way (default false)"`
 }
 
 var SearchCPETool = &mcp.Tool{
-	Name:        "search_cpe",
-	Title:       "Search CPE",
-	Description: "Search for CPEs by component fields (vendor, product, version, part) and return matching CPEs with their associated CVEs.",
+	Name:  "search_cpe",
+	Title: "Search CPE",
+	Description: "Search for CPEs by component fields (vendor, product, version, part) and return matching CPEs with their associated CVEs. " +
+		"vulnerable_only narrows the CVEs listed against each CPE, not the CPEs returned; there is no filter here for \"only vulnerable components\".",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
+}
+
+// noPagingRouteNote is this tool's route clause, and it is the one that says there is no
+// route. The upstream endpoint caps a page at 100 CPEs and does accept a page parameter,
+// but the SDK request type exposes neither page nor limit, so this tool cannot send them —
+// and partialSetNote on its own would point a caller at a page 2 it has no way to fetch.
+const noPagingRouteNote = "this tool cannot reach the rest: it has no page, limit or cursor " +
+	"argument, and the upstream page is capped at 100 CPEs. To enumerate a vendor or product " +
+	"use get_cpe_cves with a wildcard CPE, or a backup of the index"
+
+// searchCPEResult carries the matches under the shared envelope. This endpoint does not
+// paginate through this tool, so there is no cursor.
+type searchCPEResult struct {
+	envelope
+	Data []vulncheck.SearchResponseDataOut `json:"data"`
 }
 
 func registerSearchCPE(srv *mcp.Server, vc client.Client) {
@@ -42,6 +59,14 @@ func MakeSearchCPEHandler(vc client.Client) mcp.ToolHandlerFor[searchCPEArgs, an
 			return nil, nil, fmt.Errorf("searching CPE: %w", err)
 		}
 
-		return capResult(result)
+		response := searchCPEResult{
+			envelope: newEnvelope(len(result.Data), result.Total, ""),
+			Data:     result.Data,
+		}
+		if response.Total > response.Returned {
+			response.Notes = append(response.Notes, partialSetNote, noPagingRouteNote)
+		}
+
+		return capResult(response)
 	}
 }

--- a/internal/server/search_cve.go
+++ b/internal/server/search_cve.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/vulncheck-oss/mcp/internal/client"
+	vulncheck "github.com/vulncheck-oss/sdk-go-v2/v2"
 )
 
 type searchCVEArgs struct {
@@ -22,6 +23,14 @@ var SearchCVETool = &mcp.Tool{
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
 	},
+}
+
+// searchCVEResult carries the hits under the shared envelope. The client result has the
+// core fields already, but returning it directly left the tool with no notes field and no
+// returned count, so a trimmed page could not say how much of it was actually present.
+type searchCVEResult struct {
+	envelope
+	Data []vulncheck.IndexCveSearchHit `json:"data"`
 }
 
 func registerSearchCVE(srv *mcp.Server, vc client.Client) {
@@ -47,6 +56,20 @@ func MakeSearchCVEHandler(vc client.Client) mcp.ToolHandlerFor[searchCVEArgs, an
 			return nil, nil, fmt.Errorf("searching CVE: %w", err)
 		}
 
-		return capResult(result)
+		response := searchCVEResult{
+			envelope: newEnvelope(len(result.Data), int(result.Total), result.NextCursor),
+			Data:     result.Data,
+		}
+		// Without this the tool reports 5 rows against a total of 3,501 and says nothing
+		// about either fact — neither that the rows are a fraction of the match, nor
+		// that a cursor is how to see the rest.
+		if response.Total > response.Returned {
+			response.Notes = append(response.Notes, partialSetNote)
+			if response.NextCursor == "" && args.Cursor == "" {
+				response.Notes = append(response.Notes, cursorRouteNote)
+			}
+		}
+
+		return capResult(response)
 	}
 }

--- a/internal/server/search_cve_test.go
+++ b/internal/server/search_cve_test.go
@@ -82,3 +82,55 @@ func TestMakeSearchCVEHandler(t *testing.T) {
 		})
 	}
 }
+
+// TestSearchCVE_RouteNoteOnlyWhenNoWalkIsUnderWay pins the gate on cursorRouteNote.
+//
+// The last page of a cursor walk carries no next_cursor, exactly like a first page that was
+// never asked for one. Without checking the request, a caller holding the final page is told
+// to "set start_cursor true on the first call" — sent back to the beginning of a walk it has
+// just finished. The index tools gate the same way, on CursorContinuation.
+func TestSearchCVE_RouteNoteOnlyWhenNoWalkIsUnderWay(t *testing.T) {
+	hits := make([]vulncheck.IndexCveSearchHit, 5)
+	mock := &mockClient{
+		searchCVEFn: func(context.Context, client.SearchCVEQuery) (*client.SearchCVEResult, error) {
+			// Partial, and no cursor coming back: the shape shared by a first page and
+			// a last page.
+			return &client.SearchCVEResult{Data: hits, Total: 3_501}, nil
+		},
+	}
+
+	tests := []struct {
+		name      string
+		args      searchCVEArgs
+		wantRoute bool
+	}{
+		{
+			name:      "no walk under way: name the route",
+			args:      searchCVEArgs{CVE: "CVE-2021-44228"},
+			wantRoute: true,
+		},
+		{
+			name:      "last page of a walk: the caller already knows the route",
+			args:      searchCVEArgs{CVE: "CVE-2021-44228", Cursor: "abc"},
+			wantRoute: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runTool(t, mock, func(vc client.Client) toolCall {
+				return call(MakeSearchCVEHandler(vc), tt.args)
+			})
+
+			var got searchCVEResult
+			require.NoError(t, json.Unmarshal([]byte(payloadText(t, result)), &got))
+
+			assert.Contains(t, got.Notes, partialSetNote, "the set is partial either way")
+			if tt.wantRoute {
+				assert.Contains(t, got.Notes, cursorRouteNote)
+			} else {
+				assert.NotContains(t, got.Notes, cursorRouteNote)
+			}
+		})
+	}
+}

--- a/internal/server/search_docs.go
+++ b/internal/server/search_docs.go
@@ -25,14 +25,19 @@ var SearchDocsTool = &mcp.Tool{
 	},
 }
 
+// searchDocsResult carries the pages under the shared envelope.
+//
+// It was the last list-returning tool outside that contract, reporting its match count as
+// `matched`. The distinction was imagined: `total` means how many matched upstream and
+// `returned` how many are present, which is exactly what this tool has. It does not
+// paginate, so it never carries a cursor, and it searches a locally-parsed index rather
+// than API records, so it stays outside capResult and the byte budget.
 type searchDocsResult struct {
+	envelope
 	Query    string         `json:"query,omitempty"`
 	Section  string         `json:"section,omitempty"`
-	Data     []DocPage      `json:"data,omitempty"`
-	Returned int            `json:"returned"`
-	Matched  int            `json:"matched"`
 	Sections []SectionCount `json:"sections,omitempty"`
-	Notes    []string       `json:"notes,omitempty"`
+	Data     []DocPage      `json:"data"`
 }
 
 const (
@@ -58,7 +63,13 @@ func MakeSearchDocsHandler(vc client.Client) mcp.ToolHandlerFor[searchDocsArgs, 
 		}
 
 		pages := parseDocsIndex(raw)
-		result := searchDocsResult{Query: args.Query}
+		// Data starts as an empty slice, not nil, and carries no omitempty: a search
+		// matching nothing must return `data: []` rather than drop the field, or "no
+		// pages matched" is indistinguishable from a malfunction. omitempty elides an
+		// empty slice as readily as a nil one, so the tag had to go for the count to
+		// mean anything. Browse mode answers with sections and legitimately has no
+		// pages, which `data: []` states plainly alongside the note explaining why.
+		result := searchDocsResult{Query: args.Query, Data: []DocPage{}}
 
 		if args.Query == "" {
 			// Returning every page here would cost a large share of the caller's context
@@ -71,7 +82,7 @@ func MakeSearchDocsHandler(vc client.Client) mcp.ToolHandlerFor[searchDocsArgs, 
 			matches, total := searchDocsIndex(pages, args.Query, args.Section)
 			result.Data = matches
 			result.Returned = len(matches)
-			result.Matched = total
+			result.Total = total
 
 			switch {
 			case total == 0:

--- a/internal/server/search_docs_test.go
+++ b/internal/server/search_docs_test.go
@@ -211,8 +211,41 @@ func TestSearchDocs_ReportsNoMatchExplicitly(t *testing.T) {
 
 	got := decodeDocs(t, res)
 	assert.Empty(t, got.Data)
-	assert.Zero(t, got.Matched)
+	assert.Zero(t, got.Total)
 	assert.Contains(t, strings.Join(got.Notes, " "), "nothing matched")
+}
+
+// TestSearchDocs_EmptyDataIsPresentNotOmitted covers what the test above cannot.
+//
+// decodeDocs unmarshals into searchDocsResult, so an absent `data` and an empty one both
+// arrive as a nil slice and Empty() passes either way. The field used to be tagged
+// omitempty, which elides an empty slice as readily as a nil one, so a search matching
+// nothing dropped `data` altogether — indistinguishable from a malfunction, and the exact
+// defect the response envelope exists to prevent. Asserting on the raw payload is the only
+// way to see it.
+func TestSearchDocs_EmptyDataIsPresentNotOmitted(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args searchDocsArgs
+	}{
+		{"a search matching nothing", searchDocsArgs{Query: "kubernetes helm chart"}},
+		// Browse mode answers with sections and legitimately has no pages. `data: []`
+		// says so; a missing field would leave the caller guessing.
+		{"browse mode", searchDocsArgs{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res, _, err := MakeSearchDocsHandler(docsMock(docsFixture, nil))(
+				context.Background(), nil, tt.args)
+			require.NoError(t, err)
+
+			payload := decodeNumeric(t, payloadText(t, res))
+			require.Contains(t, payload, "data",
+				"data must be present when empty, not omitted")
+			assert.Empty(t, payload["data"], "and it must be an empty list, not null")
+			require.Contains(t, payload, "returned")
+			assert.Equal(t, json.Number("0"), payload["returned"])
+		})
+	}
 }
 
 func TestSearchDocs_ReportsWhenMoreMatchedThanShown(t *testing.T) {
@@ -233,7 +266,7 @@ func TestSearchDocs_ReportsWhenMoreMatchedThanShown(t *testing.T) {
 	got := decodeDocs(t, res)
 	assert.Len(t, got.Data, maxDocsResults)
 	assert.Equal(t, maxDocsResults, got.Returned)
-	assert.Equal(t, maxDocsResults+5, got.Matched, "the caller is told how much it did not see")
+	assert.Equal(t, maxDocsResults+5, got.Total, "the caller is told how much it did not see")
 	assert.Contains(t, strings.Join(got.Notes, " "), "narrow the query")
 }
 

--- a/internal/server/search_index.go
+++ b/internal/server/search_index.go
@@ -52,6 +52,8 @@ var SearchIndexTool = &mcp.Tool{
 	Title: "Search Index",
 	Description: "Query a VulnCheck index by name (required). Use list_indices to discover available index names. " +
 		"Filter by CVE, alias, IAVA, JVNDB ID, threat actor, MITRE ATT&CK group, MISP ID, ransomware group, botnet, and date ranges. Supports sorting and cursor-based pagination. " +
+		"Indices accept different filters, and one an index does not support is ignored rather than rejected: the response is unfiltered, with no error and a total that looks right. " +
+		"Call describe_index first for an unfamiliar index — it reports which filters that index actually accepts and the values each one takes. " +
 		"For IP Intelligence, Target Intelligence and Canary Intelligence use search_ip_intel, search_target_intel and search_canaries instead — they expose host and network filters this tool does not.",
 	Annotations: &mcp.ToolAnnotations{
 		ReadOnlyHint: true,
@@ -59,9 +61,8 @@ var SearchIndexTool = &mcp.Tool{
 }
 
 type searchIndexResult struct {
-	Data       []json.RawMessage `json:"data"`
-	NextCursor string            `json:"next_cursor,omitempty"`
-	Total      int               `json:"total"`
+	envelope
+	Data []json.RawMessage `json:"data"`
 }
 
 func registerSearchIndex(srv *mcp.Server, vc client.Client) {
@@ -108,10 +109,12 @@ func MakeSearchIndexHandler(vc client.Client) mcp.ToolHandlerFor[searchIndexArgs
 			return nil, nil, fmt.Errorf("searching index: %w", err)
 		}
 
-		return capResult(searchIndexResult{
-			Data:       result.Data,
-			NextCursor: result.NextCursor,
-			Total:      result.Total,
-		})
+		response := searchIndexResult{
+			envelope: newEnvelope(len(result.Data), result.Total, result.NextCursor),
+			Data:     result.Data,
+		}
+		response.Notes = indexNotes(args.Index, result)
+
+		return capResult(response)
 	}
 }

--- a/internal/server/search_index_test.go
+++ b/internal/server/search_index_test.go
@@ -32,9 +32,12 @@ func TestMakeSearchIndexHandler(t *testing.T) {
 				Total:      100,
 			},
 			wantResult: searchIndexResult{
-				Data:       []json.RawMessage{json.RawMessage(`{"id":"CVE-2021-44228"}`)},
-				NextCursor: "next",
-				Total:      100,
+				Data: []json.RawMessage{json.RawMessage(`{"id":"CVE-2021-44228"}`)},
+				envelope: envelope{
+					Returned:   1,
+					Total:      100,
+					NextCursor: "next",
+				},
 			},
 		},
 		{
@@ -86,6 +89,7 @@ func TestMakeSearchIndexHandler(t *testing.T) {
 			text := result.Content[0].(*mcp.TextContent).Text
 			var got searchIndexResult
 			require.NoError(t, json.Unmarshal([]byte(text), &got))
+			assert.Equal(t, tt.wantResult.Returned, got.Returned)
 			assert.Equal(t, tt.wantResult.Total, got.Total)
 			assert.Equal(t, tt.wantResult.NextCursor, got.NextCursor)
 			assert.Len(t, got.Data, len(tt.wantResult.Data))

--- a/internal/server/search_purls.go
+++ b/internal/server/search_purls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/vulncheck-oss/mcp/internal/client"
+	vulncheck "github.com/vulncheck-oss/sdk-go-v2/v2"
 )
 
 type searchPURLsArgs struct {
@@ -21,6 +22,16 @@ var SearchPURLsTool = &mcp.Tool{
 	},
 }
 
+// searchPURLsResult carries the findings under the shared envelope.
+//
+// It also fixes a defect of returning the client result directly: that type tags Data
+// `omitempty`, so a query matching nothing dropped the field altogether and "no findings"
+// was indistinguishable from "the field is missing". Here data is always present.
+type searchPURLsResult struct {
+	envelope
+	Data []vulncheck.PurlBatchVulnFinding `json:"data"`
+}
+
 func registerSearchPURLs(srv *mcp.Server, vc client.Client) {
 	mcp.AddTool(srv, SearchPURLsTool, MakeSearchPURLsHandler(vc))
 }
@@ -32,6 +43,9 @@ func MakeSearchPURLsHandler(vc client.Client) mcp.ToolHandlerFor[searchPURLsArgs
 			return nil, nil, fmt.Errorf("searching PURLs: %w", err)
 		}
 
-		return capResult(result)
+		return capResult(searchPURLsResult{
+			envelope: newEnvelope(len(result.Data), result.Total, ""),
+			Data:     result.Data,
+		})
 	}
 }


### PR DESCRIPTION
### What

Create a uniform response envelope for every tool that returns a list of API records. (i.e. excluding list_indices, list_backups etc).

Previously an empty result looked the same as that from a filter that was silently dropped or a genuine no match.

(The upstream API ignores a filter an index does not accept and responds with a 200 and an unfiltered result. This PR is to work around that but can be revisited when the api behaviour is changed).

### Change

A shared envelope, carried by the twelve tools that return API records plus search_docs:

{ data, returned, total, next_cursor, notes[] }

Dropped filters are now named in the notes. The client records which filters it actually put on the request, and /v3/index publishes the index's own parameter list inline with every response. We just compare the two and where they disagree the notes contains FILTERS NOT APPLIED.

next_cursor is carried wherever the tool paginates.

Also get_cpe_cves now returns "data" instead of "cves", and search_docs returns "total" instead of "matched", to bring them inline with the api and the other tools.

Testing

- make test && make lint pass, and the live suite passes against prod.
- Checked every filter the product tools send against the parameter list each index publishes, so none of them can report a false drop.